### PR TITLE
Feature/FFU-2/user avatars

### DIFF
--- a/config/common.go
+++ b/config/common.go
@@ -1,6 +1,8 @@
 package config
 
 type Common struct {
+	RenderDefaultUrl  string `yaml:"render_default_url" envconfig:"RENDER_DEFAULT_URL"`
+	RenderInternalUrl string `yaml:"render_internal_url" envconfig:"RENDER_INTERNAL_URL"`
 }
 
 func (x *Common) Init() {

--- a/universe/api/dto/dto.go
+++ b/universe/api/dto/dto.go
@@ -37,6 +37,10 @@ type Profile struct {
 	ImageHash   string  `json:"imageHash"`
 }
 
+type HashResponse struct {
+	Hash string `json:"hash"`
+}
+
 type User struct {
 	ID          string          `json:"id"`
 	UserTypeID  string          `json:"userTypeId"`

--- a/universe/node/api.go
+++ b/universe/node/api.go
@@ -43,6 +43,7 @@ func (n *Node) RegisterAPI(r *gin.Engine) {
 		authProfile := auth.Group("/profile")
 		{
 			authProfile.PATCH("", n.apiProfileUpdate)
+			authProfile.POST("/avatar/upload", n.apiProfileUploadAvatar)
 		}
 
 		authSpaces := auth.Group("/spaces")

--- a/universe/node/api.go
+++ b/universe/node/api.go
@@ -43,7 +43,7 @@ func (n *Node) RegisterAPI(r *gin.Engine) {
 		authProfile := auth.Group("/profile")
 		{
 			authProfile.PATCH("", n.apiProfileUpdate)
-			authProfile.POST("/avatar/upload", n.apiProfileUploadAvatar)
+			authProfile.POST("/avatar", n.apiProfileUploadAvatar)
 		}
 
 		authSpaces := auth.Group("/spaces")

--- a/universe/node/api_profile.go
+++ b/universe/node/api_profile.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"encoding/json"
-	"io"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -139,18 +138,12 @@ func (n *Node) apiProfileUploadAvatar(c *gin.Context) {
 
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		err := errors.WithMessage(err, "Node: apiProfileUploadAvatar: failed to read data response")
-		api.AbortRequest(c, http.StatusInternalServerError, "failed_to_response", err, n.log)
-		return
-	}
-
 	response := dto.HashResponse{}
 
-	if err := json.Unmarshal(body, &response); err != nil {
-		err := errors.WithMessage(err, "Node: apiProfileUploadAvatar: failed to unmarshal json")
-		api.AbortRequest(c, http.StatusInternalServerError, "failed_to_unmarshal_response", err, n.log)
+	errs := json.NewDecoder(resp.Body).Decode(&response)
+	if errs != nil {
+		err := errors.WithMessage(err, "Node: apiProfileUploadAvatar: failed to decode json into response")
+		api.AbortRequest(c, http.StatusBadRequest, "failed_to_decode", err, n.log)
 		return
 	}
 

--- a/universe/node/api_profile.go
+++ b/universe/node/api_profile.go
@@ -112,12 +112,13 @@ func (n *Node) apiProfileUploadAvatar(c *gin.Context) {
 	}
 
 	openedFile, err := file.Open()
-	defer openedFile.Close()
 	if err != nil {
 		err := errors.WithMessage(err, "Node: apiProfileUploadAvatar: failed to open file")
 		api.AbortRequest(c, http.StatusBadRequest, "failed_to_open", err, n.log)
 		return
 	}
+
+	defer openedFile.Close()
 
 	req, err := http.NewRequest("POST", n.cfg.Common.RenderInternalUrl+"/render/addimage", openedFile)
 	if err != nil {

--- a/universe/node/api_profile.go
+++ b/universe/node/api_profile.go
@@ -98,8 +98,8 @@ func (n *Node) apiProfileUpdate(c *gin.Context) {
 // @Description Sends an image file to the media manager and returns a hash
 // @Tags profile
 // @Accept json
-// @Produce string
-// @Success 201 {object} dto.HashResponse
+// @Produce json
+// @Success 200 {object} dto.HashResponse
 // @Success 500 {object} api.HTTPError
 // @Success 400 {object} api.HTTPError
 // @Router /api/v4/profile [patch]
@@ -154,5 +154,5 @@ func (n *Node) apiProfileUploadAvatar(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusCreated, response)
+	c.JSON(http.StatusOK, response)
 }

--- a/universe/node/api_profile.go
+++ b/universe/node/api_profile.go
@@ -120,8 +120,8 @@ func (n *Node) apiProfileUploadAvatar(c *gin.Context) {
 
 	req, err := http.NewRequest("POST", n.cfg.Common.RenderDefaultUrl, openedFile)
 	if err != nil {
-		err := errors.WithMessage(err, "Node: apiProfileUploadAvatar: failed to post data to media-manager")
-		api.AbortRequest(c, http.StatusBadRequest, "failed_to_post", err, n.log)
+		err := errors.WithMessage(err, "Node: apiProfileUploadAvatar: failed to create post request")
+		api.AbortRequest(c, http.StatusBadRequest, "failed_to_create_request", err, n.log)
 		return
 	}
 
@@ -131,9 +131,12 @@ func (n *Node) apiProfileUploadAvatar(c *gin.Context) {
 	resp, err := client.Do(req)
 	if err != nil {
 		err := errors.WithMessage(err, "Node: apiProfileUploadAvatar: failed to post data to media-manager")
-		api.AbortRequest(c, http.StatusBadRequest, "failed_to_post", err, n.log)
+		api.AbortRequest(c, http.StatusBadRequest, "failed_to_post_request", err, n.log)
 		return
 	}
 
+	defer resp.Body.Close()
+
+	// body, err := io
 	fmt.Sprintln(resp)
 }


### PR DESCRIPTION
So this endpoint will enable users to upload avatars, it uses native http client since gin does not support this as far as i can see. Media-manager returns a json response with a hash which i unmarshalled into a dto.

You can test this locally by forwarding media-manager ports with kubectl