### PR TITLE
Frontend/node url configuration

### DIFF
--- a/config/local.go
+++ b/config/local.go
@@ -5,6 +5,8 @@ type Local struct {
 	Port             uint   `yaml:"bind_port" envconfig:"UBERCONTROLLER_BIND_PORT"`
 	LogLevel         int    `yaml:"loglevel"  envconfig:"UBERCONTROLLER_LOGLEVEL"`
 	ExtensionStorage string `yaml:"storage"  envconfig:"UBERCONTROLLER_STORAGE"`
+	// TODO: rename FrontendURL to avoid confusing this with 'the frontend'
+	FrontendURL string `yaml:"frontend_url" json:"-" envconfig:"FRONTEND_URL"` // URL where this instance is reachable (e.g. when behind a proxy)
 }
 
 func (x *Local) Init() {
@@ -12,4 +14,5 @@ func (x *Local) Init() {
 	x.Address = "0.0.0.0"
 	x.Port = 4000
 	x.ExtensionStorage = "/opt/ubercontroller"
+	x.FrontendURL = "http://localhost:4000"
 }

--- a/config/uiclient.go
+++ b/config/uiclient.go
@@ -3,7 +3,6 @@ package config
 type UIClient struct {
 	AgoraAppID                    string `yaml:"agora_app_id" json:"AGORA_APP_ID" envconfig:"AGORA_APP_ID"`
 	BlockchainWsServer            string `yaml:"blockchain_ws_server" json:"BLOCKCHAIN_WS_SERVER" envconfig:"BLOCKCHAIN_WS_SERVER"`
-	FrontendURL                   string `yaml:"frontend_url" json:"-" envconfig:"FRONTEND_URL"` // TODO: refactory: remove from ui-client (not used?, only internally) and rename
 	NFTAdminAddress               string `yaml:"nft_admin_address" json:"NFT_ADMIN_ADDRESS" envconfig:"NFT_ADMIN_ADDRESS"`
 	NFTCollectionOdysseyID        string `yaml:"nft_collection_odyssey_id" json:"NFT_COLLECTION_ODYSSEY_ID" envconfig:"NFT_COLLECTION_ODYSSEY_ID"`
 	StreamchatKey                 string `yaml:"streamchat_key" json:"STREAMCHAT_KEY" envconfig:"STREAMCHAT_KEY"`

--- a/config/uiclient.go
+++ b/config/uiclient.go
@@ -3,7 +3,7 @@ package config
 type UIClient struct {
 	AgoraAppID                    string `yaml:"agora_app_id" json:"AGORA_APP_ID" envconfig:"AGORA_APP_ID"`
 	BlockchainWsServer            string `yaml:"blockchain_ws_server" json:"BLOCKCHAIN_WS_SERVER" envconfig:"BLOCKCHAIN_WS_SERVER"`
-	FrontendURL                   string `yaml:"frontend_url" json:"-" envconfig:"FRONTEND_URL"`
+	FrontendURL                   string `yaml:"frontend_url" json:"-" envconfig:"FRONTEND_URL"` // TODO: refactory: remove from ui-client (not used?, only internally) and rename
 	NFTAdminAddress               string `yaml:"nft_admin_address" json:"NFT_ADMIN_ADDRESS" envconfig:"NFT_ADMIN_ADDRESS"`
 	NFTCollectionOdysseyID        string `yaml:"nft_collection_odyssey_id" json:"NFT_COLLECTION_ODYSSEY_ID" envconfig:"NFT_COLLECTION_ODYSSEY_ID"`
 	StreamchatKey                 string `yaml:"streamchat_key" json:"STREAMCHAT_KEY" envconfig:"STREAMCHAT_KEY"`

--- a/universe/node/api_config.go
+++ b/universe/node/api_config.go
@@ -36,7 +36,7 @@ func (n *Node) apiGetUIClientConfig(c *gin.Context) {
 	if n.cfg.UIClient.UnityClientURL != "" {
 		unityClientURLString = n.cfg.UIClient.UnityClientURL
 	} else {
-		unityClientURLString = n.cfg.UIClient.FrontendURL + "/unity"
+		unityClientURLString = n.cfg.Settings.FrontendURL + "/unity"
 	}
 	unityClientURL, err := url.Parse(unityClientURLString)
 	if err != nil {
@@ -51,8 +51,8 @@ func (n *Node) apiGetUIClientConfig(c *gin.Context) {
 		UnityClientDataURL:      unityClientURL.JoinPath(n.cfg.UIClient.UnityDataFileName).String(),
 		UnityClientFrameworkURL: unityClientURL.JoinPath(n.cfg.UIClient.UnityFrameworkFileName).String(),
 		UnityClientCodeURL:      unityClientURL.JoinPath(n.cfg.UIClient.UnityCodeFileName).String(),
-		RenderServiceURL:        n.cfg.UIClient.FrontendURL + "/api/v3/render",
-		BackendEndpointURL:      n.cfg.UIClient.FrontendURL + "/api/v3/backend",
+		RenderServiceURL:        n.cfg.Settings.FrontendURL + "/api/v3/render",
+		BackendEndpointURL:      n.cfg.Settings.FrontendURL + "/api/v3/backend",
 	}
 
 	c.JSON(http.StatusOK, out)

--- a/universe/node/api_drive.go
+++ b/universe/node/api_drive.go
@@ -424,7 +424,7 @@ func (n *Node) apiResolveNode(c *gin.Context) {
 		NodeID uuid.UUID `json:"node_id"`
 	}
 
-	u, err := url.ParseRequestURI(n.cfg.UIClient.FrontendURL)
+	u, err := url.ParseRequestURI(n.cfg.Settings.FrontendURL)
 	if err != nil {
 		err = errors.WithMessage(err, "Node: apiDriveResolveNode: failed to parse url from config")
 		api.AbortRequest(c, http.StatusInternalServerError, "invalid_request_param", err, n.log)

--- a/universe/node/api_drive.go
+++ b/universe/node/api_drive.go
@@ -424,7 +424,13 @@ func (n *Node) apiResolveNode(c *gin.Context) {
 		NodeID uuid.UUID `json:"node_id"`
 	}
 
-	u, _ := url.Parse(n.cfg.UIClient.FrontendURL)
+	u, err := url.ParseRequestURI(n.cfg.UIClient.FrontendURL)
+	if err != nil {
+		err = errors.WithMessage(err, "Node: apiDriveResolveNode: failed to parse url from config")
+		api.AbortRequest(c, http.StatusInternalServerError, "invalid_request_param", err, n.log)
+		return
+	}
+
 	h := u.Host
 	if h == "" {
 		h = "localhost"

--- a/universe/node/api_drive.go
+++ b/universe/node/api_drive.go
@@ -3,10 +3,11 @@ package node
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/momentum-xyz/ubercontroller/universe/common/helper"
 	"net/http"
 	"net/url"
 	"os/exec"
+
+	"github.com/momentum-xyz/ubercontroller/universe/common/helper"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -416,17 +417,22 @@ func (n *Node) getWalletMetadata(wallet string) (*WalletMeta, error) {
 // @Failure 400 {object} api.HTTPError
 // @Router /api/v4/drive/resolve-node [get]
 func (n *Node) apiResolveNode(c *gin.Context) {
+	// TODO: actually implement dynamic resolving of world->node
 	type Out struct {
-		Domain string    `json:"domain"`
+		Domain string    `json:"domain"` // TODO: deprecated, remove once no usage
+		URL    string    `json:"url"`
 		NodeID uuid.UUID `json:"node_id"`
 	}
 
 	u, _ := url.Parse(n.cfg.UIClient.FrontendURL)
-	h := u.Hostname()
+	h := u.Host
 	if h == "" {
 		h = "localhost"
 	}
-	Response := Out{Domain: h, NodeID: n.GetID()}
+	Response := Out{
+		URL:    u.String(),
+		Domain: h,
+		NodeID: n.GetID()}
 
 	c.JSON(http.StatusOK, Response)
 


### PR DESCRIPTION
Not a very big change, but as a PR also as a heads up since it changes configuration which you might have in use locally.

This is required for running (the whole stack) locally for development (and indirectly for decentralized/multiple nodes).
We need to pass a full URL to the frontend, so it can connect to different ports (and without tls).

Also refactored the `FrontendUrl` configuration location, since it is not used by the frontend :)
Has a very confusing name, but could not come up with something better (and that requires also renaming the env var on the current deploy environments)
