### PR TITLE
Fix panic creating world when WorldTemplate.RandomObjects are empty

### DIFF
--- a/universe/logic/tree/worlds.go
+++ b/universe/logic/tree/worlds.go
@@ -61,19 +61,21 @@ func AddWorldFromTemplate(worldTemplate *WorldTemplate, updateDB bool) (uuid.UUI
 
 	// adding children
 	objectLabelToID := make(map[string]uuid.UUID)
-	randomObject := worldTemplate.RandomObjects[rand.Intn(len(worldTemplate.RandomObjects))]
-	worldTemplate.Objects = append(worldTemplate.Objects, randomObject)
-	for i := range worldTemplate.Objects {
-		worldTemplate.Objects[i].ParentID = *worldID
-		objectID, err := AddObjectFromTemplate(worldTemplate.Objects[i], updateDB)
-		if err != nil {
-			return uuid.Nil, errors.WithMessagef(
-				err, "failed to add object from template: %+v", worldTemplate.Objects[i],
-			)
-		}
+	if len(worldTemplate.RandomObjects) > 0 {
+		randomObject := worldTemplate.RandomObjects[rand.Intn(len(worldTemplate.RandomObjects))]
+		worldTemplate.Objects = append(worldTemplate.Objects, randomObject)
+		for i := range worldTemplate.Objects {
+			worldTemplate.Objects[i].ParentID = *worldID
+			objectID, err := AddObjectFromTemplate(worldTemplate.Objects[i], updateDB)
+			if err != nil {
+				return uuid.Nil, errors.WithMessagef(
+					err, "failed to add object from template: %+v", worldTemplate.Objects[i],
+				)
+			}
 
-		if worldTemplate.Objects[i].Label != nil {
-			objectLabelToID[*worldTemplate.Objects[i].Label] = objectID
+			if worldTemplate.Objects[i].Label != nil {
+				objectLabelToID[*worldTemplate.Objects[i].Label] = objectID
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes

```
2023-02-24T09:39:12.842Z	INFO	node/api_users.go:156	Node: createUserFromWalletMeta: user created: 210d7795-f168-4d6c-bb2a-bc5f7233ae53
2023-02-24T09:39:12.848Z	INFO	node/api_drive.go:304	Node: mint: user created: 210d7795-f168-4d6c-bb2a-bc5f7233ae53
2023-02-24T09:39:12.854Z	INFO	world/world.go:239	Saving world: 210d7795-f168-4d6c-bb2a-bc5f7233ae53...
2023-02-24T09:39:12.859Z	INFO	world/world.go:245	World saved: 210d7795-f168-4d6c-bb2a-bc5f7233ae53
panic: invalid argument to Intn

goroutine 89858 [running]:
math/rand.(*Rand).Intn(0xc000617d40?, 0x1412160?)
	/usr/local/go/src/math/rand/rand.go:168 +0x65
math/rand.Intn(...)
	/usr/local/go/src/math/rand/rand.go:337
github.com/momentum-xyz/ubercontroller/universe/logic/tree.AddWorldFromTemplate(0xc00048a160, 0x1)
	/project/universe/logic/tree/worlds.go:64 +0x632
github.com/momentum-xyz/ubercontroller/universe/node.(*Node).createWorld(0xc00014cc60, {0x21, 0xd, 0x77, 0x95, 0xf1, 0x68, 0x4d, 0x6c, 0xbb, ...}, ...)
	/project/universe/node/api_drive.go:171 +0x1e5
github.com/momentum-xyz/ubercontroller/universe/node.(*Node).mint(0xc00014cc60, {0xc, 0xa7, 0xb5, 0x15, 0x87, 0xf6, 0x46, 0xb6, 0x97, ...}, ...)
	/project/universe/node/api_drive.go:306 +0xda5
created by github.com/momentum-xyz/ubercontroller/universe/node.(*Node).apiDriveMintOdyssey
	/project/universe/node/api_drive.go:126 +0x31b
```