### PR TITLE
Add attribute type to seed

### DIFF
--- a/seed/attribute_type.go
+++ b/seed/attribute_type.go
@@ -339,6 +339,17 @@ func seedAttributeType(ctx context.Context, node universe.Node) error {
 			description:   "Target World ID to teleport",
 			options:       nil,
 		},
+		{
+			pluginID:      universe.GetSystemPluginID(),
+			attributeName: "object_color",
+			description:   "Holds the object color",
+			options: &entry.AttributeOptions{
+				"unity_auto": map[string]any{
+					"slot_type":    "string",
+					"content_type": "string",
+				},
+			},
+		},
 		//
 		{
 			pluginID:      uuid.MustParse(textPluginID),


### PR DESCRIPTION
Fix error for future data seeds
```
2023-02-28T10:09:00.197Z	ERROR	api/api.go:21	Node: apiSetObjectAttributesValue: failed to upsert object attribute: failed to upsert object attribute: failed to exec db: ERROR: insert or update on table "object_attribute" violates foreign key constraint "fk_3" (SQLSTATE 23503)
```