### PR TITLE
fix: Asset3d UpdatedAt field changed to non-pointer field

### DIFF
--- a/types/entry/asset_3d.go
+++ b/types/entry/asset_3d.go
@@ -11,7 +11,7 @@ type Asset3d struct {
 	Meta      *Asset3dMeta    `db:"meta" json:"meta"`
 	Options   *Asset3dOptions `db:"options" json:"options"`
 	CreatedAt time.Time       `db:"created_at" json:"created_at"`
-	UpdatedAt *time.Time      `db:"updated_at" json:"updated_at"`
+	UpdatedAt time.Time       `db:"updated_at" json:"updated_at"`
 }
 
 type Asset3dMeta map[string]any


### PR DESCRIPTION
It's causing panic when trying to load `?category=custom` assets at `universe/assets_3d/api_assets_3d.go:72` doing `asset.UpdatedAt.Format(time.RFC3339)`