### PR TITLE
feat: export user creation function from Node

### DIFF
--- a/universe/interfaces.go
+++ b/universe/interfaces.go
@@ -93,6 +93,8 @@ type Node interface {
 	GetUserUserAttributes() UserUserAttributes
 	GetObjectUserAttributes() ObjectUserAttributes
 
+	CreateUsers(ctx context.Context, users ...*entry.User) error // TODO: refactor, place Users next to Nodes in a universe
+
 	AddAPIRegister(register APIRegister)
 
 	WriteInfluxPoint(point *influxWrite.Point) error

--- a/universe/node/api_users.go
+++ b/universe/node/api_users.go
@@ -2,8 +2,9 @@ package node
 
 import (
 	"context"
-	"github.com/momentum-xyz/ubercontroller/utils/umid"
 	"net/http"
+
+	"github.com/momentum-xyz/ubercontroller/utils/umid"
 
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
@@ -108,7 +109,7 @@ func (n *Node) apiCreateGuestUserByName(ctx context.Context, name string) (*entr
 
 	ue.UserTypeID = guestUserTypeID
 
-	err = n.db.GetUsersDB().UpsertUser(ctx, ue)
+	err = n.CreateUsers(ctx, ue)
 
 	n.log.Infof("Node: apiCreateGuestUserByName: guest created: %s", ue.UserID)
 
@@ -157,7 +158,7 @@ func (n *Node) createUserFromWalletMeta(ctx context.Context, walletMeta *WalletM
 	}
 	userEntry.UserTypeID = normUserTypeID
 
-	if err := n.db.GetUsersDB().UpsertUser(ctx, userEntry); err != nil {
+	if err := n.CreateUsers(ctx, userEntry); err != nil {
 		return nil, errors.WithMessagef(err, "failed to upsert user: %s", userEntry.UserID)
 	}
 

--- a/universe/node/users.go
+++ b/universe/node/users.go
@@ -1,8 +1,10 @@
 package node
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/momentum-xyz/ubercontroller/types/entry"
 	"github.com/momentum-xyz/ubercontroller/utils/umid"
 
 	"github.com/pkg/errors"
@@ -26,4 +28,14 @@ func (n *Node) LoadUser(userID umid.UMID) (universe.User, error) {
 	user.SetPosition(cmath.Vec3{X: 50, Y: 50, Z: 150})
 	fmt.Printf("%+v\n", user.GetPosition())
 	return user, nil
+}
+
+// Create new users on this node.
+func (n *Node) CreateUsers(ctx context.Context, users ...*entry.User) error {
+	if err := n.db.GetUsersDB().UpsertUsers(ctx, users); err != nil {
+		return errors.Wrap(err, "create users")
+	}
+	// TODO: add 'returning` to the query, so we can give back user objects
+	// with their filled in database defaults and ID.
+	return nil
 }


### PR DESCRIPTION
So user entries can be created outside of the node package.

Don't like it, node package does way too much. I think it should be refactored to place users 'next' to the nodes (inside a universe). But that's a but too much work at this point. (e.g. user could travel between nodes at some point)