### PR TITLE
Feature/transform types naming

### DIFF
--- a/database/interfaces.go
+++ b/database/interfaces.go
@@ -51,7 +51,7 @@ type ObjectsDB interface {
 	UpsertObjects(ctx context.Context, objects []*entry.Object) error
 
 	UpdateObjectParentID(ctx context.Context, objectID umid.UMID, parentID umid.UMID) error
-	UpdateObjectPosition(ctx context.Context, objectID umid.UMID, position *cmath.ObjectTransform) error
+	UpdateObjectPosition(ctx context.Context, objectID umid.UMID, position *cmath.Transform) error
 	UpdateObjectOwnerID(ctx context.Context, objectID, ownerID umid.UMID) error
 	UpdateObjectAsset2dID(ctx context.Context, objectID umid.UMID, asset2dID *umid.UMID) error
 	UpdateObjectAsset3dID(ctx context.Context, objectID umid.UMID, asset3dID *umid.UMID) error

--- a/database/objects/db.go
+++ b/database/objects/db.go
@@ -2,6 +2,7 @@ package objects
 
 import (
 	"context"
+
 	"github.com/momentum-xyz/ubercontroller/utils/umid"
 
 	"github.com/georgysavva/scany/pgxscan"
@@ -101,7 +102,7 @@ func (db *DB) UpdateObjectParentID(ctx context.Context, objectID umid.UMID, pare
 	return nil
 }
 
-func (db *DB) UpdateObjectPosition(ctx context.Context, objectID umid.UMID, position *cmath.ObjectTransform) error {
+func (db *DB) UpdateObjectPosition(ctx context.Context, objectID umid.UMID, position *cmath.Transform) error {
 	if _, err := db.conn.Exec(ctx, updateObjectPositionQuery, objectID, position); err != nil {
 		return errors.WithMessage(err, "failed to exec db")
 	}

--- a/pkg/cmath/Transform.mus.go
+++ b/pkg/cmath/Transform.mus.go
@@ -5,7 +5,7 @@ package cmath
 import "github.com/ymz-ncnk/muserrs"
 
 // MarshalMUS fills buf with the MUS encoding of v.
-func (v ObjectTransform) MarshalMUS(buf []byte) int {
+func (v Transform) MarshalMUS(buf []byte) int {
 	i := 0
 	{
 		si := v.Position.MarshalMUS(buf[i:])
@@ -23,7 +23,7 @@ func (v ObjectTransform) MarshalMUS(buf []byte) int {
 }
 
 // UnmarshalMUS parses the MUS-encoded buf, and sets the result to *v.
-func (v *ObjectTransform) UnmarshalMUS(buf []byte) (int, error) {
+func (v *Transform) UnmarshalMUS(buf []byte) (int, error) {
 	i := 0
 	var err error
 	{
@@ -66,7 +66,7 @@ func (v *ObjectTransform) UnmarshalMUS(buf []byte) (int, error) {
 }
 
 // SizeMUS returns the size of the MUS-encoded v.
-func (v ObjectTransform) SizeMUS() int {
+func (v Transform) SizeMUS() int {
 	size := 0
 	{
 		ss := v.Position.SizeMUS()

--- a/pkg/cmath/TransformNoScale.mus.go
+++ b/pkg/cmath/TransformNoScale.mus.go
@@ -5,7 +5,7 @@ package cmath
 import "github.com/ymz-ncnk/muserrs"
 
 // MarshalMUS fills buf with the MUS encoding of v.
-func (v UserTransform) MarshalMUS(buf []byte) int {
+func (v TransformNoScale) MarshalMUS(buf []byte) int {
 	i := 0
 	{
 		si := v.Position.MarshalMUS(buf[i:])
@@ -19,7 +19,7 @@ func (v UserTransform) MarshalMUS(buf []byte) int {
 }
 
 // UnmarshalMUS parses the MUS-encoded buf, and sets the result to *v.
-func (v *UserTransform) UnmarshalMUS(buf []byte) (int, error) {
+func (v *TransformNoScale) UnmarshalMUS(buf []byte) (int, error) {
 	i := 0
 	var err error
 	{
@@ -50,7 +50,7 @@ func (v *UserTransform) UnmarshalMUS(buf []byte) (int, error) {
 }
 
 // SizeMUS returns the size of the MUS-encoded v.
-func (v UserTransform) SizeMUS() int {
+func (v TransformNoScale) SizeMUS() int {
 	size := 0
 	{
 		ss := v.Position.SizeMUS()

--- a/pkg/cmath/gen/mus.go
+++ b/pkg/cmath/gen/mus.go
@@ -3,9 +3,10 @@
 package main
 
 import (
+	"reflect"
+
 	"github.com/momentum-xyz/ubercontroller/pkg/cmath"
 	"github.com/ymz-ncnk/musgo/v2"
-	"reflect"
 )
 
 func main() {
@@ -15,11 +16,11 @@ func main() {
 		panic(err)
 	}
 	unsafe := false // To generate safe code.
-	err = musGo.Generate(reflect.TypeOf((*cmath.ObjectTransform)(nil)).Elem(), unsafe)
+	err = musGo.Generate(reflect.TypeOf((*cmath.Transform)(nil)).Elem(), unsafe)
 	if err != nil {
 		panic(err)
 	}
-	err = musGo.Generate(reflect.TypeOf((*cmath.UserTransform)(nil)).Elem(), unsafe)
+	err = musGo.Generate(reflect.TypeOf((*cmath.TransformNoScale)(nil)).Elem(), unsafe)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/cmath/math.go
+++ b/pkg/cmath/math.go
@@ -20,7 +20,7 @@ type Vec3 struct {
 
 // Transform represent a transformation for an object in 3D space.
 type Transform struct {
-	Position Vec3 `db:"location" json:"location"`
+	Position Vec3 `db:"location" json:"position"`
 	Rotation Vec3 `db:"rotation" json:"rotation"`
 	Scale    Vec3 `db:"scale" json:"scale"`
 }
@@ -28,7 +28,7 @@ type Transform struct {
 // TransformNoScale represents a transformation for an object in 3D space that has no scale.
 // For example, users don't have a scale in the current system.
 type TransformNoScale struct { // TODO: come up with a better name, winner gets a prize!
-	Position Vec3 `db:"location" json:"location"`
+	Position Vec3 `db:"location" json:"position"`
 	Rotation Vec3 `db:"rotation" json:"rotation"`
 }
 

--- a/pkg/cmath/math.go
+++ b/pkg/cmath/math.go
@@ -11,20 +11,23 @@ const (
 	Float32Bytes = 4
 )
 
+// Vec3 is a three dimensional vector.
 type Vec3 struct {
 	X float32 `json:"x" db:"x"`
 	Y float32 `json:"y" db:"y"`
 	Z float32 `json:"z" db:"z"`
 }
 
-// TODO: rename to "Transform"
-type ObjectTransform struct {
+// Transform represent a transformation for an object in 3D space.
+type Transform struct {
 	Position Vec3 `db:"location" json:"location"`
 	Rotation Vec3 `db:"rotation" json:"rotation"`
 	Scale    Vec3 `db:"scale" json:"scale"`
 }
 
-type UserTransform struct {
+// TransformNoScale represents a transformation for an object in 3D space that has no scale.
+// For example, users don't have a scale in the current system.
+type TransformNoScale struct { // TODO: come up with a better name, winner gets a prize!
 	Position Vec3 `db:"location" json:"location"`
 	Rotation Vec3 `db:"rotation" json:"rotation"`
 }
@@ -110,7 +113,7 @@ func DefaultPosition() Vec3 {
 //	return t
 //}
 
-func (t *UserTransform) CopyToBuffer(b []byte) error {
+func (t *TransformNoScale) CopyToBuffer(b []byte) error {
 	binary.LittleEndian.PutUint32(b, math.Float32bits(t.Position.X))
 	binary.LittleEndian.PutUint32(b[Float32Bytes:], math.Float32bits(t.Position.Y))
 	binary.LittleEndian.PutUint32(b[2*Float32Bytes:], math.Float32bits(t.Position.Z))
@@ -136,8 +139,8 @@ func (t *UserTransform) CopyToBuffer(b []byte) error {
 //	return nil
 //}
 
-func (t *UserTransform) Copy() UserTransform {
-	t1 := UserTransform{}
+func (t *TransformNoScale) Copy() TransformNoScale {
+	t1 := TransformNoScale{}
 	t1.Position = t.Position
 	t1.Rotation = t.Rotation
 	return t1

--- a/pkg/posbus/ObjectDefinition.mus.go
+++ b/pkg/posbus/ObjectDefinition.mus.go
@@ -182,7 +182,7 @@ func (v *ObjectDefinition) UnmarshalMUS(buf []byte) (int, error) {
 		return i, muserrs.NewFieldError("Name", err)
 	}
 	{
-		var sv cmath.ObjectTransform
+		var sv cmath.Transform
 		si := 0
 		si, err = sv.UnmarshalMUS(buf[i:])
 		if err == nil {

--- a/pkg/posbus/ObjectPosition.mus.go
+++ b/pkg/posbus/ObjectPosition.mus.go
@@ -39,7 +39,7 @@ func (v *ObjectPosition) UnmarshalMUS(buf []byte) (int, error) {
 		return i, muserrs.NewFieldError("ID", err)
 	}
 	{
-		var sv cmath.ObjectTransform
+		var sv cmath.Transform
 		si := 0
 		si, err = sv.UnmarshalMUS(buf[i:])
 		if err == nil {

--- a/pkg/posbus/ObjectTransform.mus.go
+++ b/pkg/posbus/ObjectTransform.mus.go
@@ -9,7 +9,7 @@ import (
 )
 
 // MarshalMUS fills buf with the MUS encoding of v.
-func (v ObjectPosition) MarshalMUS(buf []byte) int {
+func (v ObjectTransform) MarshalMUS(buf []byte) int {
 	i := 0
 	{
 		si := v.ID.MarshalMUS(buf[i:])
@@ -23,7 +23,7 @@ func (v ObjectPosition) MarshalMUS(buf []byte) int {
 }
 
 // UnmarshalMUS parses the MUS-encoded buf, and sets the result to *v.
-func (v *ObjectPosition) UnmarshalMUS(buf []byte) (int, error) {
+func (v *ObjectTransform) UnmarshalMUS(buf []byte) (int, error) {
 	i := 0
 	var err error
 	{
@@ -54,7 +54,7 @@ func (v *ObjectPosition) UnmarshalMUS(buf []byte) (int, error) {
 }
 
 // SizeMUS returns the size of the MUS-encoded v.
-func (v ObjectPosition) SizeMUS() int {
+func (v ObjectTransform) SizeMUS() int {
 	size := 0
 	{
 		ss := v.ID.SizeMUS()

--- a/pkg/posbus/UserData.mus.go
+++ b/pkg/posbus/UserData.mus.go
@@ -133,7 +133,7 @@ func (v *UserData) UnmarshalMUS(buf []byte) (int, error) {
 		return i, muserrs.NewFieldError("Avatar", err)
 	}
 	{
-		var sv cmath.UserTransform
+		var sv cmath.TransformNoScale
 		si := 0
 		si, err = sv.UnmarshalMUS(buf[i:])
 		if err == nil {

--- a/pkg/posbus/UserTransform.mus.go
+++ b/pkg/posbus/UserTransform.mus.go
@@ -39,7 +39,7 @@ func (v *UserTransform) UnmarshalMUS(buf []byte) (int, error) {
 		return i, muserrs.NewFieldError("ID", err)
 	}
 	{
-		var sv cmath.UserTransform
+		var sv cmath.TransformNoScale
 		si := 0
 		si, err = sv.UnmarshalMUS(buf[i:])
 		if err == nil {

--- a/pkg/posbus/my_transform.go
+++ b/pkg/posbus/my_transform.go
@@ -4,7 +4,7 @@ import (
 	"github.com/momentum-xyz/ubercontroller/pkg/cmath"
 )
 
-type MyTransform cmath.UserTransform
+type MyTransform cmath.TransformNoScale
 
 func init() {
 	registerMessage(MyTransform{})

--- a/pkg/posbus/object_definition.go
+++ b/pkg/posbus/object_definition.go
@@ -7,15 +7,15 @@ import (
 )
 
 type ObjectDefinition struct {
-	ID               umid.UMID             `json:"id"`
-	ParentID         umid.UMID             `json:"parent_id"`
-	AssetType        umid.UMID             `json:"asset_type"`
-	AssetFormat      dto.Asset3dType       `json:"asset_format"` // TODO: Rename AssetType to AssetID, so Type can be used for this.
-	Name             string                `json:"name"`
-	Transform        cmath.ObjectTransform `json:"transform"`
-	IsEditable       bool                  `json:"is_editable"`
-	TetheredToParent bool                  `json:"tethered_to_parent"`
-	ShowOnMiniMap    bool                  `json:"show_on_minimap"`
+	ID               umid.UMID       `json:"id"`
+	ParentID         umid.UMID       `json:"parent_id"`
+	AssetType        umid.UMID       `json:"asset_type"`
+	AssetFormat      dto.Asset3dType `json:"asset_format"` // TODO: Rename AssetType to AssetID, so Type can be used for this.
+	Name             string          `json:"name"`
+	Transform        cmath.Transform `json:"transform"`
+	IsEditable       bool            `json:"is_editable"`
+	TetheredToParent bool            `json:"tethered_to_parent"`
+	ShowOnMiniMap    bool            `json:"show_on_minimap"`
 	//InfoUI           umid.UMID
 }
 

--- a/pkg/posbus/object_position.go
+++ b/pkg/posbus/object_position.go
@@ -5,15 +5,16 @@ import (
 	"github.com/momentum-xyz/ubercontroller/utils/umid"
 )
 
-type ObjectPosition struct {
+// ObjectTransform is a transform to apply to a specific object.
+type ObjectTransform struct {
 	ID        umid.UMID       `json:"id"`
 	Transform cmath.Transform `json:"object_transform"`
 }
 
 func init() {
-	registerMessage(ObjectPosition{})
+	registerMessage(ObjectTransform{})
 }
 
-func (g *ObjectPosition) GetType() MsgType {
+func (g *ObjectTransform) GetType() MsgType {
 	return 0xEA6DA4B4
 }

--- a/pkg/posbus/object_position.go
+++ b/pkg/posbus/object_position.go
@@ -6,8 +6,8 @@ import (
 )
 
 type ObjectPosition struct {
-	ID        umid.UMID             `json:"id"`
-	Transform cmath.ObjectTransform `json:"object_transform"`
+	ID        umid.UMID       `json:"id"`
+	Transform cmath.Transform `json:"object_transform"`
 }
 
 func init() {

--- a/pkg/posbus/types.autogen.go
+++ b/pkg/posbus/types.autogen.go
@@ -15,7 +15,7 @@ const (
 	TypeNotification          MsgType = 0xC1FB41D7
 	TypeObjectData            MsgType = 0xCACE197C
 	TypeObjectDefinition      MsgType = 0xD742B52E
-	TypeObjectPosition        MsgType = 0xEA6DA4B4
+	TypeObjectTransform       MsgType = 0xEA6DA4B4
 	TypeRemoveObjects         MsgType = 0x6BF88C24
 	TypeRemoveUsers           MsgType = 0xF5A14BB0
 	TypeSetWorld              MsgType = 0xCCDF2E49

--- a/pkg/posbus/user_data.go
+++ b/pkg/posbus/user_data.go
@@ -6,11 +6,11 @@ import (
 )
 
 type UserData struct {
-	ID        umid.UMID           `json:"id"`
-	Name      string              `json:"name"`
-	Avatar    umid.UMID           `json:"avatar"`
-	Transform cmath.UserTransform `json:"transform"`
-	IsGuest   bool                `json:"is_guest"`
+	ID        umid.UMID              `json:"id"`
+	Name      string                 `json:"name"`
+	Avatar    umid.UMID              `json:"avatar"`
+	Transform cmath.TransformNoScale `json:"transform"`
+	IsGuest   bool                   `json:"is_guest"`
 }
 
 func init() {

--- a/pkg/posbus/users_transform_list.go
+++ b/pkg/posbus/users_transform_list.go
@@ -11,9 +11,11 @@ const UserTransformMessageSize = MsgUUIDTypeSize + cmath.Float32Bytes*6
 //	registerMessage(&UsersTransformList{})
 //}
 
+
+// UserTransform is a transform to apply to a specific user.
 type UserTransform struct {
-	ID        umid.UMID           `json:"id"`
-	Transform cmath.UserTransform `json:"transform"`
+	ID        umid.UMID              `json:"id"`
+	Transform cmath.TransformNoScale `json:"transform"`
 }
 
 type UsersTransformList struct {

--- a/pkg/position_algo/algo.go
+++ b/pkg/position_algo/algo.go
@@ -12,5 +12,5 @@ const (
 
 type Algo interface {
 	Name() string
-	CalcPos(parentTheta float64, parentPosition cmath.ObjectTransform, i, n int) (cmath.ObjectTransform, float64)
+	CalcPos(parentTheta float64, parentPosition cmath.Transform, i, n int) (cmath.Transform, float64)
 }

--- a/pkg/position_algo/circular.go
+++ b/pkg/position_algo/circular.go
@@ -27,8 +27,8 @@ func NewCircular(parameterMap map[string]interface{}) Algo {
 	}
 }
 
-func (cir *circular) CalcPos(parentTheta float64, parentPosition cmath.ObjectTransform, i, n int) (
-	cmath.ObjectTransform, float64,
+func (cir *circular) CalcPos(parentTheta float64, parentPosition cmath.Transform, i, n int) (
+	cmath.Transform, float64,
 ) {
 	parent := parentPosition.Position.ToVec3f64()
 	phi := -0.5*math.Pi + cir.Angle/180.0*math.Pi + parentTheta
@@ -41,7 +41,7 @@ func (cir *circular) CalcPos(parentTheta float64, parentPosition cmath.ObjectTra
 		Z: math.Round((parent.Z+cir.R*math.Sin(angle))*10.0) / 10.0,
 	}
 
-	np := cmath.ObjectTransform{Position: p.ToVec3()}
+	np := cmath.Transform{Position: p.ToVec3()}
 	return np, math.Atan2(p.Z-parent.Z, p.X-parent.X) /* theta */
 }
 

--- a/pkg/position_algo/helix.go
+++ b/pkg/position_algo/helix.go
@@ -33,8 +33,8 @@ func NewHelix(parameterMap map[string]interface{}) Algo {
 	}
 }
 
-func (h *helix) CalcPos(parentTheta float64, parentPosition cmath.ObjectTransform, i, n int) (
-	cmath.ObjectTransform, float64,
+func (h *helix) CalcPos(parentTheta float64, parentPosition cmath.Transform, i, n int) (
+	cmath.Transform, float64,
 ) {
 	parent := parentPosition.Position.ToVec3f64()
 	id := float64(i)
@@ -51,7 +51,7 @@ func (h *helix) CalcPos(parentTheta float64, parentPosition cmath.ObjectTransfor
 		Z: math.Round((parent.Z+r*math.Sin(angle))*10.0) / 10.0,
 	}
 
-	np := cmath.ObjectTransform{Position: p.ToVec3()}
+	np := cmath.Transform{Position: p.ToVec3()}
 	return np, math.Atan2(p.Z-parent.Z, p.X-parent.X) /* theta */
 }
 

--- a/pkg/position_algo/hexaspiral.go
+++ b/pkg/position_algo/hexaspiral.go
@@ -39,8 +39,8 @@ func NewHexaSpiral(parameterMap map[string]interface{}) Algo {
 	}
 }
 
-func (h *hexaSpiral) CalcPos(parentTheta float64, parentPosition cmath.ObjectTransform, i, n int) (
-	cmath.ObjectTransform, float64,
+func (h *hexaSpiral) CalcPos(parentTheta float64, parentPosition cmath.Transform, i, n int) (
+	cmath.Transform, float64,
 ) {
 	parent := parentPosition.Position.ToVec3f64()
 
@@ -61,7 +61,7 @@ func (h *hexaSpiral) CalcPos(parentTheta float64, parentPosition cmath.ObjectTra
 		Z: math.Round((parent.Z+y*h.Robject)*10.0) / 10.0,
 	}
 
-	np := cmath.ObjectTransform{Position: p.ToVec3()}
+	np := cmath.Transform{Position: p.ToVec3()}
 	return np, math.Atan2(p.Z-parent.Z, p.X-parent.X) /* theta */
 }
 

--- a/pkg/position_algo/sector.go
+++ b/pkg/position_algo/sector.go
@@ -27,8 +27,8 @@ func NewSector(parameterMap map[string]interface{}) Algo {
 	}
 }
 
-func (sec *sector) CalcPos(parentTheta float64, parentPosition cmath.ObjectTransform, i, n int) (
-	cmath.ObjectTransform, float64,
+func (sec *sector) CalcPos(parentTheta float64, parentPosition cmath.Transform, i, n int) (
+	cmath.Transform, float64,
 ) {
 	parent := parentPosition.Position.ToVec3f64()
 
@@ -46,7 +46,7 @@ func (sec *sector) CalcPos(parentTheta float64, parentPosition cmath.ObjectTrans
 		Z: math.Round((parent.Z+sec.R*math.Sin(angle))*10.0) / 10.0,
 	}
 
-	np := cmath.ObjectTransform{Position: p.ToVec3()}
+	np := cmath.Transform{Position: p.ToVec3()}
 	return np, math.Atan2(p.Z-parent.Z, p.X-parent.X) /* theta */
 }
 

--- a/pkg/position_algo/spiral.go
+++ b/pkg/position_algo/spiral.go
@@ -30,8 +30,8 @@ func NewSpiral(parameterMap map[string]interface{}) Algo {
 	}
 }
 
-func (s *spiral) CalcPos(parentTheta float64, parentPosition cmath.ObjectTransform, i, n int) (
-	cmath.ObjectTransform, float64,
+func (s *spiral) CalcPos(parentTheta float64, parentPosition cmath.Transform, i, n int) (
+	cmath.Transform, float64,
 ) {
 	parent := parentPosition.Position.ToVec3f64()
 	scl := math.Sqrt(s.Scale * (float64(i) + s.Angle))
@@ -46,7 +46,7 @@ func (s *spiral) CalcPos(parentTheta float64, parentPosition cmath.ObjectTransfo
 		Z: math.Round((parent.Z+r*math.Sin(angle))*10.0) / 10.0,
 	}
 
-	np := cmath.ObjectTransform{Position: p.ToVec3()}
+	np := cmath.Transform{Position: p.ToVec3()}
 	return np, math.Atan2(p.Z-parent.Z, p.X-parent.X) /* theta */
 }
 

--- a/types/entry/object.go
+++ b/types/entry/object.go
@@ -1,9 +1,10 @@
 package entry
 
 import (
+	"time"
+
 	"github.com/momentum-xyz/ubercontroller/pkg/cmath"
 	"github.com/momentum-xyz/ubercontroller/utils/umid"
-	"time"
 )
 
 type ObjectVisibleType byte
@@ -16,16 +17,16 @@ const (
 )
 
 type Object struct {
-	ObjectID     umid.UMID              `db:"object_id" json:"object_id"`
-	ObjectTypeID umid.UMID              `db:"object_type_id" json:"object_type_id"`
-	OwnerID      umid.UMID              `db:"owner_id" json:"owner_id"`
-	ParentID     umid.UMID              `db:"parent_id" json:"parent_id"`
-	Asset2dID    *umid.UMID             `db:"asset_2d_id" json:"asset_2d_id"`
-	Asset3dID    *umid.UMID             `db:"asset_3d_id" json:"asset_3d_id"`
-	Options      *ObjectOptions         `db:"options" json:"options"`
-	Position     *cmath.ObjectTransform `db:"position" json:"position"`
-	CreatedAt    time.Time              `db:"created_at" json:"created_at"`
-	UpdatedAt    time.Time              `db:"updated_at" json:"updated_at"`
+	ObjectID     umid.UMID        `db:"object_id" json:"object_id"`
+	ObjectTypeID umid.UMID        `db:"object_type_id" json:"object_type_id"`
+	OwnerID      umid.UMID        `db:"owner_id" json:"owner_id"`
+	ParentID     umid.UMID        `db:"parent_id" json:"parent_id"`
+	Asset2dID    *umid.UMID       `db:"asset_2d_id" json:"asset_2d_id"`
+	Asset3dID    *umid.UMID       `db:"asset_3d_id" json:"asset_3d_id"`
+	Options      *ObjectOptions   `db:"options" json:"options"`
+	Position     *cmath.Transform `db:"position" json:"position"`
+	CreatedAt    time.Time        `db:"created_at" json:"created_at"`
+	UpdatedAt    time.Time        `db:"updated_at" json:"updated_at"`
 }
 
 type ObjectOptions struct {

--- a/universe/interfaces.go
+++ b/universe/interfaces.go
@@ -152,10 +152,10 @@ type Object interface {
 	GetOwnerID() umid.UMID
 	SetOwnerID(ownerID umid.UMID, updateDB bool) error
 
-	GetTransform() *cmath.ObjectTransform
-	GetActualTransform() *cmath.ObjectTransform
-	SetTransform(position *cmath.ObjectTransform, updateDB bool) error
-	SetActualTransform(pos cmath.ObjectTransform, theta float64) error
+	GetTransform() *cmath.Transform
+	GetActualTransform() *cmath.Transform
+	SetTransform(position *cmath.Transform, updateDB bool) error
+	SetActualTransform(pos cmath.Transform, theta float64) error
 
 	GetOptions() *entry.ObjectOptions
 	GetEffectiveOptions() *entry.ObjectOptions
@@ -217,8 +217,8 @@ type User interface {
 
 	GetProfile() *entry.UserProfile
 
-	GetTransform() *cmath.UserTransform
-	SetTransform(cmath.UserTransform)
+	GetTransform() *cmath.TransformNoScale
+	SetTransform(cmath.TransformNoScale)
 
 	GetPosition() cmath.Vec3
 	GetRotation() cmath.Vec3

--- a/universe/logic/api/dto/dto.go
+++ b/universe/logic/api/dto/dto.go
@@ -91,12 +91,12 @@ type User struct {
 }
 
 type Object struct {
-	OwnerID      string                `json:"owner_id"`
-	ParentID     string                `json:"parent_id"`
-	ObjectTypeID string                `json:"object_type_id"`
-	Asset2dID    string                `json:"asset_2d_id"`
-	Asset3dID    string                `json:"asset_3d_id"`
-	Position     cmath.ObjectTransform `json:"position"`
+	OwnerID      string          `json:"owner_id"`
+	ParentID     string          `json:"parent_id"`
+	ObjectTypeID string          `json:"object_type_id"`
+	Asset2dID    string          `json:"asset_2d_id"`
+	Asset3dID    string          `json:"asset_3d_id"`
+	Position     cmath.Transform `json:"position"`
 }
 
 type Asset2d struct {

--- a/universe/logic/tree/objects.go
+++ b/universe/logic/tree/objects.go
@@ -15,19 +15,19 @@ import (
 )
 
 type ObjectTemplate struct {
-	ObjectID         *umid.UMID             `json:"object_id"`
-	ObjectName       *string                `json:"object_name"`
-	ObjectTypeID     umid.UMID              `json:"object_type_id"`
-	ParentID         umid.UMID              `json:"parent_id"`
-	OwnerID          *umid.UMID             `json:"owner_id"`
-	Asset2dID        *umid.UMID             `json:"asset_2d_id"`
-	Asset3dID        *umid.UMID             `json:"asset_3d_id"`
-	Options          *entry.ObjectOptions   `json:"options"`
-	Position         *cmath.ObjectTransform `json:"position"`
-	Label            *string                `json:"label"`
-	ObjectAttributes []*entry.Attribute     `json:"object_attributes"`
-	Objects          []*ObjectTemplate      `json:"objects"`
-	RandomObjects    []*ObjectTemplate      `json:"random_objects"`
+	ObjectID         *umid.UMID           `json:"object_id"`
+	ObjectName       *string              `json:"object_name"`
+	ObjectTypeID     umid.UMID            `json:"object_type_id"`
+	ParentID         umid.UMID            `json:"parent_id"`
+	OwnerID          *umid.UMID           `json:"owner_id"`
+	Asset2dID        *umid.UMID           `json:"asset_2d_id"`
+	Asset3dID        *umid.UMID           `json:"asset_3d_id"`
+	Options          *entry.ObjectOptions `json:"options"`
+	Position         *cmath.Transform     `json:"position"`
+	Label            *string              `json:"label"`
+	ObjectAttributes []*entry.Attribute   `json:"object_attributes"`
+	Objects          []*ObjectTemplate    `json:"objects"`
+	RandomObjects    []*ObjectTemplate    `json:"random_objects"`
 }
 
 func AddObjectFromTemplate(objectTemplate *ObjectTemplate, updateDB bool) (umid.UMID, error) {

--- a/universe/logic/tree/positions.go
+++ b/universe/logic/tree/positions.go
@@ -8,13 +8,13 @@ import (
 	"github.com/momentum-xyz/ubercontroller/universe"
 )
 
-func CalcObjectSpawnPosition(parentID, userID umid.UMID) (*cmath.ObjectTransform, error) {
+func CalcObjectSpawnPosition(parentID, userID umid.UMID) (*cmath.Transform, error) {
 	parent, ok := universe.GetNode().GetObjectFromAllObjects(parentID)
 	if !ok {
 		return nil, errors.Errorf("object parent not found: %s", parentID)
 	}
 
-	var position *cmath.ObjectTransform
+	var position *cmath.Transform
 	effectiveOptions := parent.GetEffectiveOptions()
 	if effectiveOptions == nil || len(effectiveOptions.ChildPlacements) == 0 {
 		world := parent.GetWorld()
@@ -22,7 +22,7 @@ func CalcObjectSpawnPosition(parentID, userID umid.UMID) (*cmath.ObjectTransform
 			user, ok := world.GetUser(userID, true)
 			if ok {
 				//distance := float32(10)
-				position = &cmath.ObjectTransform{
+				position = &cmath.Transform{
 					// TODO: recalc based on euler angles, not lookat: Position: cmath.Add(user.GetTransform(), cmath.MultiplyN(user.GetRotation(), distance)),
 					Position: user.GetPosition(),
 					Rotation: cmath.Vec3{},

--- a/universe/node/api_objects.go
+++ b/universe/node/api_objects.go
@@ -1,8 +1,9 @@
 package node
 
 import (
-	"github.com/momentum-xyz/ubercontroller/utils/umid"
 	"net/http"
+
+	"github.com/momentum-xyz/ubercontroller/utils/umid"
 
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
@@ -30,13 +31,13 @@ func (n *Node) apiObjectsCreateObject(c *gin.Context) {
 	// TODO: use "helper.ObjectTemplate" alternative here to have ability to create composite objects
 	// QUESTION: can we automatically clone "helper.ObjectTemplate" definition and add validation tags to it?
 	type InBody struct {
-		ObjectName   string                 `json:"object_name" binding:"required"`
-		ParentID     string                 `json:"parent_id" binding:"required"`
-		ObjectTypeID string                 `json:"object_type_id" binding:"required"`
-		Asset2dID    *string                `json:"asset_2d_id"`
-		Asset3dID    *string                `json:"asset_3d_id"`
-		Position     *cmath.ObjectTransform `json:"position"`
-		Minimap      bool                   `json:"minimap"`
+		ObjectName   string           `json:"object_name" binding:"required"`
+		ParentID     string           `json:"parent_id" binding:"required"`
+		ObjectTypeID string           `json:"object_type_id" binding:"required"`
+		Asset2dID    *string          `json:"asset_2d_id"`
+		Asset3dID    *string          `json:"asset_3d_id"`
+		Position     *cmath.Transform `json:"position"`
+		Minimap      bool             `json:"minimap"`
 	}
 	var inBody InBody
 

--- a/universe/object/object.go
+++ b/universe/object/object.go
@@ -2,11 +2,12 @@ package object
 
 import (
 	"context"
+	"sync/atomic"
+
 	"github.com/momentum-xyz/ubercontroller/config"
 	"github.com/momentum-xyz/ubercontroller/pkg/posbus"
 	"github.com/momentum-xyz/ubercontroller/seed"
 	"github.com/momentum-xyz/ubercontroller/utils/umid"
-	"sync/atomic"
 
 	"github.com/gorilla/websocket"
 	"github.com/pkg/errors"
@@ -41,7 +42,7 @@ type Object struct {
 	//Mu               sync.RWMutex
 	Mu               deadlock.RWMutex
 	ownerID          umid.UMID
-	transform        *cmath.ObjectTransform
+	transform        *cmath.Transform
 	options          *entry.ObjectOptions
 	Parent           universe.Object
 	asset2d          universe.Asset2d
@@ -54,7 +55,7 @@ type Object struct {
 	attributesMsg     *generic.SyncMap[string, *generic.SyncMap[string, *websocket.PreparedMessage]]
 	renderDataMap     *generic.SyncMap[posbus.ObjectDataIndex, interface{}]
 	dataMsg           atomic.Pointer[websocket.PreparedMessage]
-	actualPosition    atomic.Pointer[cmath.ObjectTransform]
+	actualPosition    atomic.Pointer[cmath.Transform]
 	broadcastPipeline chan *websocket.PreparedMessage
 	messageAccept     atomic.Bool
 	numSendsQueued    atomic.Int64
@@ -140,7 +141,7 @@ func (o *Object) Initialize(ctx context.Context) error {
 	o.numSendsQueued.Store(chanIsClosed)
 	o.lockedBy.Store(umid.Nil)
 
-	newPos := cmath.ObjectTransform{Position: *new(cmath.Vec3), Rotation: *new(cmath.Vec3), Scale: *new(cmath.Vec3)}
+	newPos := cmath.Transform{Position: *new(cmath.Vec3), Rotation: *new(cmath.Vec3), Scale: *new(cmath.Vec3)}
 	o.actualPosition.Store(&newPos)
 
 	return nil

--- a/universe/object/placement.go
+++ b/universe/object/placement.go
@@ -1,9 +1,10 @@
 package object
 
 import (
+	"sort"
+
 	"github.com/momentum-xyz/ubercontroller/pkg/posbus"
 	"github.com/momentum-xyz/ubercontroller/utils/umid"
-	"sort"
 
 	"github.com/pkg/errors"
 
@@ -57,7 +58,7 @@ func (o *Object) GetPlacements() map[umid.UMID]position_algo.Algo {
 	return pls
 }
 
-func (o *Object) SetActualTransform(pos cmath.ObjectTransform, theta float64) error {
+func (o *Object) SetActualTransform(pos cmath.Transform, theta float64) error {
 	o.Mu.Lock()
 	defer o.Mu.Unlock()
 
@@ -82,18 +83,18 @@ func (o *Object) SetActualTransform(pos cmath.ObjectTransform, theta float64) er
 	return nil
 }
 
-func (o *Object) GetTransform() *cmath.ObjectTransform {
+func (o *Object) GetTransform() *cmath.Transform {
 	o.Mu.RLock()
 	defer o.Mu.RUnlock()
 
 	return o.transform
 }
 
-func (o *Object) GetActualTransform() *cmath.ObjectTransform {
+func (o *Object) GetActualTransform() *cmath.Transform {
 	return o.actualPosition.Load()
 }
 
-func (o *Object) SetTransform(position *cmath.ObjectTransform, updateDB bool) error {
+func (o *Object) SetTransform(position *cmath.Transform, updateDB bool) error {
 	o.Mu.Lock()
 	defer o.Mu.Unlock()
 

--- a/universe/object/placement.go
+++ b/universe/object/placement.go
@@ -72,7 +72,7 @@ func (o *Object) SetActualTransform(pos cmath.Transform, theta float64) error {
 				world := o.GetWorld()
 				if world != nil {
 					world.Send(
-						posbus.WSMessage(&posbus.ObjectPosition{ID: o.id, Transform: *o.GetActualTransform()}),
+						posbus.WSMessage(&posbus.ObjectTransform{ID: o.id, Transform: *o.GetActualTransform()}),
 						true,
 					)
 				}
@@ -115,7 +115,7 @@ func (o *Object) SetTransform(position *cmath.Transform, updateDB bool) error {
 				world := o.GetWorld()
 				if world != nil {
 					world.Send(
-						posbus.WSMessage(&posbus.ObjectPosition{ID: o.id, Transform: *o.GetActualTransform()}),
+						posbus.WSMessage(&posbus.ObjectTransform{ID: o.id, Transform: *o.GetActualTransform()}),
 						true,
 					)
 				}

--- a/universe/user/message_loop.go
+++ b/universe/user/message_loop.go
@@ -45,7 +45,7 @@ func (u *User) OnMessage(buf []byte) error {
 	return nil
 }
 
-func (u *User) UpdateObjectPosition(msg posbus.ObjectPosition) error {
+func (u *User) UpdateObjectPosition(msg posbus.ObjectTransform) error {
 	object, ok := universe.GetNode().GetObjectFromAllObjects(msg.ID)
 	if !ok {
 		return errors.Errorf("object not found: %s", msg.ID)

--- a/universe/user/user.go
+++ b/universe/user/user.go
@@ -2,6 +2,10 @@ package user
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
 	"github.com/gorilla/websocket"
 	"github.com/momentum-xyz/ubercontroller/pkg/posbus"
 	"github.com/momentum-xyz/ubercontroller/universe/logic/common"
@@ -9,9 +13,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sasha-s/go-deadlock"
 	"go.uber.org/zap"
-	"sync"
-	"sync/atomic"
-	"time"
 
 	"github.com/momentum-xyz/ubercontroller/database"
 	"github.com/momentum-xyz/ubercontroller/pkg/cmath"
@@ -30,7 +31,7 @@ type User struct {
 	// The websocket connection.
 	conn *websocket.Conn
 
-	transform cmath.UserTransform
+	transform cmath.TransformNoScale
 	//pos          *cmath.Vec3 // going to data part to posMsgBuffer content for simple access
 	//rotation     *cmath.Vec3 // going to data part to posMsgBuffer content for simple access
 	//posMsgBuffer []byte
@@ -67,11 +68,11 @@ func (u *User) GetID() umid.UMID {
 //	return t
 //}
 
-func (u *User) GetTransform() *cmath.UserTransform {
+func (u *User) GetTransform() *cmath.TransformNoScale {
 	return &u.transform
 }
 
-func (u *User) SetTransform(t cmath.UserTransform) {
+func (u *User) SetTransform(t cmath.TransformNoScale) {
 	u.transform = t.Copy()
 }
 
@@ -240,7 +241,7 @@ func (u *User) LoadFromEntry(entry *entry.User) error {
 
 func (u *User) UpdatePosition(t *posbus.MyTransform) error {
 	//u.SetTransform(t)
-	u.transform = cmath.UserTransform(*t)
+	u.transform = cmath.TransformNoScale(*t)
 	// not locking will speed up but introduce minor data race with zero impact
 	//u.world.users.positionLock.RLock()
 	//copy(u.posMsgBuffer[16:40], data)


### PR DESCRIPTION
Clearing up the name (and meaning) of 'transform' to the outside world (so our frontend).

We have duplicate ObjectTransform, UserTransform types (in posbus and cmath packages). This ends up being a bit confusing to use ( in the auto generated types) for users of posbus/api.
Transform is commonly understood to be position+rotation+scale in the 3D
world. Our UserTransform is the exception. Remove the 'user' from this
name, since this is a math only package and doesn't know anything about how it is used.

We also outputted the position field as location in json. Make that position again, to sync up with the naming used in 3d engines.

So refactor, rename, no functional changes.