### PR TITLE
feat(api): optionally add pprof endpoints

### DIFF
--- a/config/common.go
+++ b/config/common.go
@@ -5,6 +5,9 @@ type Common struct {
 	RenderInternalURL   string `yaml:"render_internal_url" envconfig:"RENDER_INTERNAL_URL"`
 	MnemonicPhrase      string `yaml:"mnemonic_phrase" envconfig:"MNEMONIC_PHRASE"`
 	AllowCORS           bool   `yaml:"allow_cors" envconfig:"ALLOW_CORS"`
+
+	// Enabled pprof http endpoints. If enabled, point your browser at /debug/pprof
+	PProfAPI bool `yaml:"pprof_api" envconfig:"PPROF_API"`
 }
 
 func (x *Common) Init() {

--- a/universe/node/api.go
+++ b/universe/node/api.go
@@ -20,6 +20,10 @@ import (
 func (n *Node) RegisterAPI(r *gin.Engine) {
 	n.log.Infof("Registering api for node: %s...", n.GetID())
 
+	if n.cfg.Common.PProfAPI {
+		registerPProfAPI(r.Group("/debug"))
+	}
+
 	if n.cfg.Common.AllowCORS {
 		r.Use(cors.New(cors.Config{
 			AllowOrigins: []string{"*"},

--- a/universe/node/api_pprof.go
+++ b/universe/node/api_pprof.go
@@ -1,0 +1,23 @@
+package node
+
+import (
+	"net/http/pprof"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Expose the pprof http endpoints in Gin framework.
+// See https://pkg.go.dev/runtime/pprof
+func registerPProfAPI(g *gin.RouterGroup) {
+	g.GET("/pprof", gin.WrapF(pprof.Index))
+	g.GET("/cmdline", gin.WrapF(pprof.Cmdline))
+	g.GET("/profile", gin.WrapF(pprof.Profile))
+	g.GET("/symbol", gin.WrapF(pprof.Symbol))
+	g.POST("/symbol", gin.WrapF(pprof.Symbol))
+	g.GET("/trace", gin.WrapF(pprof.Trace))
+
+	// https://pkg.go.dev/runtime/pprof#Profile
+	for _, s := range []string{"allocs", "block", "goroutine", "heap", "mutex", "threadcreate"} {
+		g.GET(s, gin.WrapH(pprof.Handler(s)))
+	}
+}


### PR DESCRIPTION
Allows controlling profiling through http calls.

These are the 'default' pprof http handlers.
Equivalent to a `import _ "net/http/pprof"` but wrapped in this projects GIN framework.
