### PR TITLE
fix: add users message on world spawn/connect

### DIFF
--- a/universe/world/users.go
+++ b/universe/world/users.go
@@ -193,6 +193,9 @@ func (w *World) initializeUI(user universe.User) error {
 	w.SendAllAutoAttributes(user.SendDirectly, true)
 	w.log.Infof("Sent Textures: %+v\n", user.GetID())
 	user.ReleaseSendBuffer()
+
+	w.SendUsersSpawnMessage(user.Send)
+	w.log.Infof("Sent all users: %+v\n", user.GetID())
 	return nil
 }
 

--- a/universe/world/world.go
+++ b/universe/world/world.go
@@ -241,6 +241,42 @@ func (w *World) broadcastPositions() {
 	}
 }
 
+// Send posbus.AddUsers containing all current users in the world (including themself).
+// Accepts a function, which should be the function to send the message to a user.
+//
+// Similar to Object.SendSpawnMessage, but not prepared like objects (stored on world).
+// This changes more often and would require some fine-grained hooks into the add/remove user logic.
+// (Also it just changed, since this new user was added)
+func (w *World) SendUsersSpawnMessage(sendFn func(*websocket.PreparedMessage) error) {
+	// See broadcastPositions, same logic, just different contents
+	w.Users.Mu.RLock()
+	numClients := len(w.Users.Data)
+	batchSize := 100 // Sane size for UserData? contains variable name string.
+	var msgBatches []posbus.AddUsers
+	if numClients > 0 {
+		uDatas := make([]posbus.UserData, 0)
+		for _, u := range w.Users.Data {
+			uDatas = append(uDatas, *u.GetUserDefinition())
+		}
+		nrUpdates := len(uDatas)
+		msgBatches = make([]posbus.AddUsers, 0, (nrUpdates+batchSize-1)/batchSize)
+
+		generic.NewButcher(uDatas).HandleBatchesSync(
+			batchSize,
+			func(batch []posbus.UserData) error {
+				msg := posbus.AddUsers{}
+				msg.Users = batch
+				msgBatches = append(msgBatches, msg)
+				return nil
+			},
+		)
+	}
+	w.Users.Mu.RUnlock()
+	for _, msg := range msgBatches {
+		sendFn(posbus.WSMessage(&msg))
+	}
+}
+
 func (w *World) Load() error {
 	w.log.Infof("Loading world: %s...", w.GetID())
 


### PR DESCRIPTION
Similar as objects inside the world, send the current state on spawn.

Previous controller version didn't have this. Only position updates were send (3d engine did API calls for this data instead).

Using a delayed/deferred user.Send, so client will first receive adduser with single entry of themself (from world 'broadcast'). After that the full list (including self). Otherwise we need filtered world broadcast.