### PR TITLE
fix(harvester): ignore error saving staking to DB

### DIFF
--- a/harvester/table2.go
+++ b/harvester/table2.go
@@ -296,7 +296,9 @@ func (t *Table2) saveToDB(wallets []Address, contracts []Address, balances []*en
 			s.WalletID, blockchainUMID, s.ObjectID, s.Amount, "")
 		if err != nil {
 			err = errors.WithMessage(err, "failed to insert stakes to DB")
-			return err
+			fmt.Println(err)
+			fmt.Println("Ignore this error as not critical")
+			// return err
 		}
 	}
 


### PR DESCRIPTION
It fails when object_id is not existing as it breaks FK. Perhaps a check could be made that it's the case, right now it ignores all staking-DB errors and just moves on.