### PR TITLE
fix(api): return proper createdAt field value

### DIFF
--- a/universe/interfaces.go
+++ b/universe/interfaces.go
@@ -2,6 +2,7 @@ package universe
 
 import (
 	"context"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
@@ -213,6 +214,9 @@ type Object interface {
 	SendAllAutoAttributes(sendFn func(msg *websocket.PreparedMessage) error, recursive bool)
 
 	LockUIObject(user User, state uint32) bool
+
+	GetCreatedAt() time.Time
+	GetUpdatedAt() time.Time
 }
 
 type User interface {

--- a/universe/worlds/api_worlds.go
+++ b/universe/worlds/api_worlds.go
@@ -252,7 +252,6 @@ func (w *Worlds) apiWorldsGetDetails(c *gin.Context) {
 	}
 
 	totalStakeStr := totalStake.String()
-	worldEntry := world.GetEntry()
 	worldDetails := dto.WorldDetails{
 		ID:                 world.GetID(),
 		OwnerID:            ownerID,
@@ -260,8 +259,8 @@ func (w *Worlds) apiWorldsGetDetails(c *gin.Context) {
 		Name:               utils.GetPTR(world.GetName()),
 		Description:        utils.GetPTR(world.GetDescription()),
 		StakeTotal:         &totalStakeStr,
-		CreatedAt:          worldEntry.CreatedAt.Format(time.RFC3339),
-		UpdatedAt:          worldEntry.UpdatedAt.Format(time.RFC3339),
+		CreatedAt:          world.GetCreatedAt().Format(time.RFC3339),
+		UpdatedAt:          world.GetUpdatedAt().Format(time.RFC3339),
 		AvatarHash:         utils.GetPTR(world.GetWorldAvatar()),
 		WebsiteLink:        utils.GetPTR(world.GetWebsiteLink()),
 		WorldStakers:       worldStakers,


### PR DESCRIPTION
Fixes the 'nil' value that is returned.
Stores these values in-mem when object gets loaded from DB.
Also initialize to Now() for newly created worlds.

Just quickfix of the bug, 'big' todo here is still actually making updatedAt change properly.

https://momentum.nifty.pm/Yok8v8pw_pmY/task/DEV-290