### PR TITLE
fix: nft metadata endpoint

### DIFF
--- a/database/interfaces.go
+++ b/database/interfaces.go
@@ -45,7 +45,6 @@ type NodesDB interface {
 type WorldsDB interface {
 	GetAllWorldIDs(ctx context.Context) ([]umid.UMID, error)
 	GetWorldIDs(ctx context.Context, sortType universe.SortType, limit string) ([]umid.UMID, error)
-	CheckIsWorldFirstHundred(ctx context.Context, objectTypeID umid.UMID, objectID umid.UMID) (*entry.Object, error)
 	GetWorlds(ctx context.Context) ([]*entry.Object, error)
 }
 

--- a/database/worlds/db.go
+++ b/database/worlds/db.go
@@ -30,12 +30,6 @@ const (
          					AND object_id != parent_id
          					ORDER BY created_at DESC
 							LIMIT 6;`
-	checkIsWorldFirstHundred = `WITH first_records AS (
-									SELECT *, ROW_NUMBER() OVER (ORDER BY created_at) AS row_num
-									FROM object WHERE object_type_id = $1
-									)
-									SELECT * FROM first_records 
-									WHERE row_num <= 100 AND object_id = $2;`
 )
 
 var _ database.WorldsDB = (*DB)(nil)
@@ -85,13 +79,4 @@ func (db *DB) GetRecentWorldIDs(ctx context.Context) ([]umid.UMID, error) {
 		return nil, errors.WithMessage(err, "failed to query db")
 	}
 	return worldIDs, nil
-}
-
-func (db *DB) CheckIsWorldFirstHundred(ctx context.Context, objectTypeID umid.UMID, objectID umid.UMID) (*entry.Object, error) {
-	var world *entry.Object
-
-	if err := pgxscan.Select(ctx, db.conn, &world, checkIsWorldFirstHundred); err != nil {
-		return nil, errors.WithMessage(err, "failed to query db")
-	}
-	return world, nil
 }

--- a/universe/worlds/api.go
+++ b/universe/worlds/api.go
@@ -26,7 +26,6 @@ func (w *Worlds) RegisterAPI(r *gin.Engine) {
 					world.GET("", w.apiWorldsGetDetails)
 					world.GET("/explore", w.apiWorldsGetObjectsWithChildren)
 					world.GET("/online-users", w.apiGetOnlineUsers)
-					world.GET("/meta-data", w.apiWorldsGetMetaData)
 					world.PATCH("", w.apiWorldsUpdateByID)
 
 					authorizedAdmin := world.Group("", middleware.AuthorizeAdmin(w.log))
@@ -36,6 +35,11 @@ func (w *Worlds) RegisterAPI(r *gin.Engine) {
 					}
 				}
 			}
+		}
+		// public endpoint for NFT listings/marketplaces
+		nfts := vx.Group("/nft")
+		{
+			nfts.GET("/:nftID", w.apiNFTMetaData)
 		}
 	}
 }

--- a/universe/worlds/api_nfts.go
+++ b/universe/worlds/api_nfts.go
@@ -1,0 +1,104 @@
+package worlds
+
+import (
+	"fmt"
+	"math/big"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/momentum-xyz/ubercontroller/types/entry"
+	"github.com/momentum-xyz/ubercontroller/universe"
+	"github.com/momentum-xyz/ubercontroller/universe/logic/api"
+	"github.com/momentum-xyz/ubercontroller/universe/logic/api/dto"
+	"github.com/momentum-xyz/ubercontroller/utils"
+	"github.com/momentum-xyz/ubercontroller/utils/umid"
+)
+
+// @Summary Get NFT metadata.
+// @Schemes
+// @Description Returns ERC721 metadata.
+// @Tags nfts
+// @Produce json
+// @Param nftID path string true "NFT token ID"
+// @Success 200 {object} dto.WorldNFTMeta
+// @Failure 400 {object} api.HTTPError
+// @Failure 404 {object} api.HTTPError
+// @Router /api/v4/nft/{nftID} [get]
+func (w *Worlds) apiNFTMetaData(c *gin.Context) {
+	nftID := c.Param("nftID")
+	tokenID := new(big.Int)
+	tokenID, ok := tokenID.SetString(nftID, 10)
+	if !ok {
+		api.AbortRequest(c, http.StatusBadRequest, "invalid_request", fmt.Errorf("failed to parse nft ID"), w.log)
+		return
+	}
+	odysseyID, err := umid.FromBytes(tokenID.FillBytes(make([]byte, 16)))
+	if err != nil {
+		api.AbortRequest(c, http.StatusBadRequest, "invalid_request", fmt.Errorf("failed to parse UMID %s: %w", tokenID, err), w.log)
+		return
+	}
+
+	var response *dto.WorldNFTMeta
+	world, ok := w.GetWorld(odysseyID)
+	if !ok {
+		response = w.nftMetadataDefault(odysseyID)
+	} else {
+		response, err = w.nftMetadata(world)
+		if err != nil {
+			api.AbortRequest(c, http.StatusBadRequest, "invalid_request", fmt.Errorf("failed to get world metadata: %w", err), w.log)
+			return
+		}
+	}
+	c.JSON(http.StatusOK, response)
+}
+
+func (w *Worlds) nftMetadataDefault(worldID umid.UMID) *dto.WorldNFTMeta {
+	seqID := utils.UMIDToSEQ(worldID)
+	objectName := "Odyssey#" + strconv.FormatUint(seqID, 10)
+	return &dto.WorldNFTMeta{
+		Name:        objectName,
+		Description: "",
+		Image:       w.nftImageDefault(),
+		Attributes:  nil,
+	}
+}
+
+func (w *Worlds) nftMetadata(world universe.World) (*dto.WorldNFTMeta, error) {
+	attributes := make([]dto.NFTAttributes, 0)
+
+	worldNr := utils.UMIDToSEQ(world.GetID())
+	if worldNr <= 100 { // Will we get more ranges like this?
+		attribute := dto.NFTAttributes{
+			TraitType: "type",
+			Value:     "origin",
+		}
+		attributes = append(attributes, attribute)
+	}
+
+	pluginID := universe.GetSystemPluginID()
+	attributeID := entry.NewAttributeID(pluginID, universe.ReservedAttributes.Object.WorldAvatar.Name)
+	imageValue, ok := world.GetObjectAttributes().GetValue(attributeID)
+	if !ok {
+		w.log.Debugf("NFT metadata: could not get image attribute for world")
+		// Ignore ok return here, no image attr, use a default fallback.
+	}
+
+	var worldAvatarHash string
+	if imageValue != nil {
+		worldAvatarHash = utils.GetFromAnyMap(*imageValue, universe.ReservedAttributes.Object.WorldAvatar.Key, "")
+	} else {
+		worldAvatarHash = w.nftImageDefault()
+	}
+
+	return &dto.WorldNFTMeta{
+		Name:        world.GetName(),
+		Description: world.GetDescription(),
+		Image:       worldAvatarHash,
+		Attributes:  attributes,
+	}, nil
+}
+
+func (w *Worlds) nftImageDefault() string {
+	return w.cfg.Settings.FrontendURL + "/api/v3/render/get/bd6563cc9fceac3e1ed6fcad752c902d"
+}

--- a/universe/worlds/api_worlds.go
+++ b/universe/worlds/api_worlds.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math/big"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -71,78 +70,6 @@ func (w *Worlds) apiGetOnlineUsers(c *gin.Context) {
 	userDTOs := converters.ToUserDTOs(userEntries, guestUserTypeID, false)
 
 	c.JSON(http.StatusOK, userDTOs)
-}
-
-// @Summary Get world nft meta data
-// @Schemes
-// @Description Returns a json object containing meta-data and traits
-// @Tags worlds
-// @Accept json
-// @Produce json
-// @Param worldID path string true "World UMID"
-// @Success 200 {array} dto.WorldNFTMeta
-// @Failure 500 {object} api.HTTPError
-// @Failure 400 {object} api.HTTPError
-// @Failure 404 {object} api.HTTPError
-// @Router /api/v4/worlds/{object_id}/meta-data [get]
-func (w *Worlds) apiWorldsGetMetaData(c *gin.Context) {
-	worldID, err := umid.Parse(c.Param("objectID"))
-	if err != nil {
-		err := errors.WithMessage(err, "Worlds: apiWorldsGetMetaData: failed to parse world umid")
-		api.AbortRequest(c, http.StatusBadRequest, "invalid_world_id", err, w.log)
-		return
-	}
-
-	world, ok := w.GetWorld(worldID)
-	if !ok || world == nil {
-		seqID := utils.UMIDToSEQ(worldID)
-		objectName := "Odyssey#" + strconv.FormatUint(seqID, 10)
-
-		worldMeta := dto.WorldNFTMeta{
-			Name:        objectName,
-			Description: "",
-			Image:       w.cfg.Common.RenderInternalURL + "/api/v3/render/get/bd6563cc9fceac3e1ed6fcad752c902d",
-			Attributes:  nil,
-		}
-
-		c.JSON(http.StatusOK, worldMeta)
-	}
-
-	attributes := make([]dto.NFTAttributes, 0)
-
-	worldEntry := world.GetEntry()
-	checkedWorld, _ := w.db.GetWorldsDB().CheckIsWorldFirstHundred(w.ctx, worldEntry.ObjectTypeID, world.GetID())
-	if checkedWorld != nil {
-		attribute := dto.NFTAttributes{
-			TraitType: "type",
-			Value:     "origin",
-		}
-
-		attributes = append(attributes, attribute)
-	}
-
-	pluginID := universe.GetSystemPluginID()
-	attributeID := entry.NewAttributeID(pluginID, universe.ReservedAttributes.Object.WorldAvatar.Name)
-	imageValue, ok := world.GetObjectAttributes().GetValue(attributeID)
-	if !ok {
-		err := errors.New("Worlds: apiWorldsGetMetaData: failed to get image attribute")
-		api.AbortRequest(c, http.StatusInternalServerError, "failed_to_get_image_attribute", err, w.log)
-		return
-	}
-
-	var worldAvatarHash string
-	if imageValue != nil {
-		worldAvatarHash = utils.GetFromAnyMap(*imageValue, universe.ReservedAttributes.Object.WorldAvatar.Key, "")
-	}
-
-	worldMeta := dto.WorldNFTMeta{
-		Name:        world.GetName(),
-		Description: world.GetDescription(),
-		Image:       worldAvatarHash,
-		Attributes:  attributes,
-	}
-
-	c.JSON(http.StatusOK, worldMeta)
 }
 
 // @Summary Get world details


### PR DESCRIPTION
Some refactoring and fixes.

- No user authentication should be required.
- Move the URL: the NFT contract specifies a base URL and appends the 'token id'. So this needs the be the last part of the path. - Parse the url param as a token ID (uint256).
- Remove the DB level check for 1st 100. Don't need it, since we have sequantial IDs (query method is broken anyway, does not pass in the proper params).
- Fix the world image URL, don't the the internal host.