### PR TITLE
build: add version information to binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 # syntax=docker/dockerfile:1.4
+ARG BUILD_VERSION
 FROM golang:1.20-alpine3.17 as build
+ARG BUILD_VERSION
 
-RUN apk add --update --no-cache gcc binutils-gold musl-dev
+RUN apk add --update --no-cache gcc make binutils-gold musl-dev
 
 WORKDIR /project
 
@@ -11,12 +13,9 @@ RUN go mod download
 
 COPY . ./
 
-
 # extra ldflag to make sure it works with alpine/musl
-
-RUN go mod vendor && go generate ./... && go build -trimpath -ldflags "-extldflags '-fuse-ld=bfd'" -o ./bin/ubercontroller ./cmd/service
-#RUN go build -o ./bin/ubercontroller ./cmd/service
-
+ENV LDFLAGS="-extldflags '-fuse-ld=bfd'" BUILD_VERSION=${BUILD_VERSION}
+RUN make build
 
 # Runtime image
 FROM alpine:3.16 as runtime

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
-DOCKER_IMAGE="ubercontroller"
-DOCKER_TAG="develop"
+BUILD_VERSION ?= $(shell git describe --tags --dirty)
+DOCKER_IMAGE  ?= ubercontroller
+DOCKER_TAG    ?= develop
+LDFLAGS       ?=
 
 all: build
 
@@ -12,7 +14,7 @@ gen-clean:
 	find . -type f \( -name "*.mus.go" -o -name "*.autogen.go" \) | xargs rm
 
 build: gen
-	go build -trimpath -o ./bin/ubercontroller ./cmd/service
+	go build -ldflags "${LDFLAGS} -X main.version=${BUILD_VERSION}" -buildvcs=false -trimpath -o ./bin/ubercontroller ./cmd/service
 	cd plugins && make
 
 run: build
@@ -27,7 +29,7 @@ build-docs:
 
 docker-build: DOCKER_BUILDKIT=1
 docker-build:
-	docker build -t ${DOCKER_IMAGE}:${DOCKER_TAG} .
+	docker build --build-arg BUILD_VERSION=${BUILD_VERSION} -t ${DOCKER_IMAGE}:${DOCKER_TAG} .
 
 # docker run ...
 docker: docker-build

--- a/cmd/service/main.go
+++ b/cmd/service/main.go
@@ -17,11 +17,16 @@ import (
 	"github.com/momentum-xyz/ubercontroller/types"
 )
 
+// Build version, overridden with flag during build.
+var version = "devel"
+
 var log = logger.L()
 
 func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
+
+	log.Debugf("Version: %s", version)
 
 	if err := run(ctx); err != nil {
 		log.Fatal(errors.WithMessage(err, "failed to run service"))


### PR DESCRIPTION
Inject the build version into the go build.

Drop the go build default buildvcs info, since we inject our own now (also to use the same system in no golang projects). Change the dockerfile to use the makefile now, to keep this in sync.