### PR TITLE
refactor: cfg/log context variables

### DIFF
--- a/cmd/service/main.go
+++ b/cmd/service/main.go
@@ -36,19 +36,21 @@ func main() {
 func run(ctx context.Context) error {
 	cfg := config.GetConfig()
 
-	ctx = context.WithValue(ctx, types.LoggerContextKey, log)
-	ctx = context.WithValue(ctx, types.ConfigContextKey, cfg)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+	nodeCtx, err := types.NewNodeContext(ctx, log, cfg)
+	if err != nil {
+		return errors.WithMessage(err, "failed to create context")
+	}
 
 	tm1 := time.Now()
-	pool, err := service.CreateDBConnection(ctx, &cfg.Postgres)
+	pool, err := service.CreateDBConnection(nodeCtx, &cfg.Postgres)
 	if err != nil {
 		return errors.WithMessage(err, "failed to create db connection")
 	}
 	defer pool.Close()
 
-	node, err := service.LoadNode(ctx, cfg, pool)
+	node, err := service.LoadNode(nodeCtx, cfg, pool)
 	if err != nil {
 		return errors.WithMessage(err, "loading node")
 	}

--- a/database/migrations/migrations.go
+++ b/database/migrations/migrations.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/momentum-xyz/ubercontroller/config"
 	"github.com/momentum-xyz/ubercontroller/types"
-	"github.com/momentum-xyz/ubercontroller/utils"
 )
 
 //go:embed sql/*
@@ -79,11 +78,11 @@ func createNewDatabase(ctx context.Context, log *zap.SugaredLogger, cfg *config.
 	return nil
 }
 
-func MigrateDatabase(ctx context.Context, cfg *config.Postgres) error {
-	log := utils.GetFromAny(ctx.Value(types.LoggerContextKey), (*zap.SugaredLogger)(nil))
-	if log == nil {
-		return errors.Errorf("failed to get logger from context: %T", ctx.Value(types.LoggerContextKey))
-	}
+func MigrateDatabase(ctx interface {
+	context.Context
+	types.LoggerContext
+}, cfg *config.Postgres) error {
+	log := ctx.Logger()
 
 	db, err := pgDBMigrationsConnect(ctx, log, cfg)
 	if err != nil {

--- a/pkg/service/run.go
+++ b/pkg/service/run.go
@@ -8,7 +8,6 @@ import (
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/pkg/errors"
-	"go.uber.org/zap"
 
 	"github.com/momentum-xyz/ubercontroller/config"
 	"github.com/momentum-xyz/ubercontroller/database"
@@ -29,7 +28,6 @@ import (
 	"github.com/momentum-xyz/ubercontroller/universe/plugins"
 	"github.com/momentum-xyz/ubercontroller/universe/user_types"
 	"github.com/momentum-xyz/ubercontroller/universe/worlds"
-	"github.com/momentum-xyz/ubercontroller/utils"
 	"github.com/momentum-xyz/ubercontroller/utils/umid"
 
 	assets2dDB "github.com/momentum-xyz/ubercontroller/database/assets_2d"
@@ -53,7 +51,9 @@ import (
 )
 
 // Load a Node
-func LoadNode(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool) (universe.Node, error) {
+func LoadNode(
+	ctx types.NodeContext,
+	cfg *config.Config, pool *pgxpool.Pool) (universe.Node, error) {
 	//todo: change to pool
 	if err := universe.InitializeIDs(
 		umid.MustParse("f0f0f0f0-0f0f-4ff0-af0f-f0f0f0f0f0f0"),
@@ -89,7 +89,7 @@ func LoadNode(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool) (univ
 	return node, nil
 }
 
-func loadNode(ctx context.Context, node universe.Node, nodeEntry *entry.Node, db database.DB) error {
+func loadNode(ctx types.NodeContext, node universe.Node, nodeEntry *entry.Node, db database.DB) error {
 
 	if nodeEntry == nil {
 		if err := seed.Node(ctx, node, db); err != nil {
@@ -103,7 +103,7 @@ func loadNode(ctx context.Context, node universe.Node, nodeEntry *entry.Node, db
 	return nil
 }
 
-func createNode(ctx context.Context, db database.DB, nodeEntry *entry.Node) (universe.Node, error) {
+func createNode(ctx types.NodeContext, db database.DB, nodeEntry *entry.Node) (universe.Node, error) {
 	worlds := worlds.NewWorlds(db)
 	assets2d := assets_2d.NewAssets2d(db)
 	assets3d := assets_3d.NewAssets3d(db)
@@ -158,8 +158,8 @@ func createNode(ctx context.Context, db database.DB, nodeEntry *entry.Node) (uni
 	return node, nil
 }
 
-func CreateDBConnection(ctx context.Context, cfg *config.Postgres) (*pgxpool.Pool, error) {
-	log := utils.GetFromAny(ctx.Value(types.LoggerContextKey), (*zap.SugaredLogger)(nil))
+func CreateDBConnection(ctx types.LoggerContext, cfg *config.Postgres) (*pgxpool.Pool, error) {
+	log := ctx.Logger()
 	config, err := cfg.GenConfig(log.Desugar())
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to gen postgres config")

--- a/seed/assets_2d.go
+++ b/seed/assets_2d.go
@@ -7,19 +7,13 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/momentum-xyz/ubercontroller/config"
-	"github.com/momentum-xyz/ubercontroller/types"
 	"github.com/momentum-xyz/ubercontroller/types/entry"
 	"github.com/momentum-xyz/ubercontroller/universe"
-	"github.com/momentum-xyz/ubercontroller/utils"
 	"github.com/momentum-xyz/ubercontroller/utils/modify"
 )
 
 func seedAssets2d(ctx context.Context, node universe.Node) error {
-	cfg := utils.GetFromAny(ctx.Value(types.ConfigContextKey), (*config.Config)(nil))
-	if cfg == nil {
-		return errors.New("failed to get config from context")
-	}
+	cfg := node.GetConfig()
 	baseUrl := cfg.Settings.FrontendURL
 	miroUrl, gdriveUrl, videoUrl, err := generatePluginUrls(baseUrl)
 	if err != nil {

--- a/seed/plugin.go
+++ b/seed/plugin.go
@@ -2,16 +2,14 @@ package seed
 
 import (
 	"context"
-	"github.com/momentum-xyz/ubercontroller/utils/umid"
 	"net/url"
+
+	"github.com/momentum-xyz/ubercontroller/utils/umid"
 
 	"github.com/pkg/errors"
 
-	"github.com/momentum-xyz/ubercontroller/config"
-	"github.com/momentum-xyz/ubercontroller/types"
 	"github.com/momentum-xyz/ubercontroller/types/entry"
 	"github.com/momentum-xyz/ubercontroller/universe"
-	"github.com/momentum-xyz/ubercontroller/utils"
 )
 
 func seedPlugins(ctx context.Context, node universe.Node) error {
@@ -20,10 +18,7 @@ func seedPlugins(ctx context.Context, node universe.Node) error {
 		Meta *entry.PluginMeta
 	}
 
-	cfg := utils.GetFromAny(ctx.Value(types.ConfigContextKey), (*config.Config)(nil))
-	if cfg == nil {
-		return errors.New("failed to get config from context")
-	}
+	cfg := node.GetConfig()
 	baseUrl := cfg.Settings.FrontendURL
 	miroUrl, gdriveUrl, videoUrl, err := generatePluginUrls(baseUrl)
 	if err != nil {

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -1,9 +1,9 @@
 package seed
 
 import (
-	"context"
 	"fmt"
 
+	"github.com/momentum-xyz/ubercontroller/types"
 	"github.com/momentum-xyz/ubercontroller/utils/umid"
 
 	"github.com/momentum-xyz/ubercontroller/database"
@@ -13,7 +13,7 @@ import (
 	"github.com/momentum-xyz/ubercontroller/universe"
 )
 
-func Node(ctx context.Context, node universe.Node, db database.DB) error {
+func Node(ctx types.NodeContext, node universe.Node, db database.DB) error {
 	group, groupCtx := errgroup.WithContext(ctx)
 
 	group.Go(
@@ -54,7 +54,7 @@ func Node(ctx context.Context, node universe.Node, db database.DB) error {
 
 	group.Go(
 		func() error {
-			return seedMedia(groupCtx)
+			return seedMedia(groupCtx, node)
 		},
 	)
 

--- a/types/contexts.go
+++ b/types/contexts.go
@@ -1,0 +1,59 @@
+package types
+
+import (
+	"context"
+	"errors"
+
+	"github.com/momentum-xyz/ubercontroller/config"
+	"go.uber.org/zap"
+)
+
+// Typed contex.Context handling
+
+const (
+	loggerContextKey = "logger"
+	configContextKey = "config"
+)
+
+type LoggerContext interface {
+	context.Context
+	Logger() *zap.SugaredLogger
+}
+
+type ConfigContext interface {
+	context.Context
+	Config() *config.Config
+}
+
+type NodeContext interface {
+	LoggerContext
+	ConfigContext
+}
+
+type nodeContext struct {
+	context.Context
+	log *zap.SugaredLogger
+	cfg *config.Config
+}
+
+func (n nodeContext) Logger() *zap.SugaredLogger {
+	return n.log
+}
+
+func (n nodeContext) Config() *config.Config {
+	return n.cfg
+}
+
+func NewNodeContext(ctx context.Context, log *zap.SugaredLogger, cfg *config.Config) (NodeContext, error) {
+	if log == nil {
+		return nil, errors.New("NodeContext: log required")
+	}
+	if cfg == nil {
+		return nil, errors.New("NodeContext: cfg required")
+	}
+	return nodeContext{
+		Context: ctx,
+		log:     log,
+		cfg:     cfg,
+	}, nil
+}

--- a/types/generic/butcher_test.go
+++ b/types/generic/butcher_test.go
@@ -7,17 +7,30 @@ package generic
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"reflect"
 	"sync"
 	"testing"
 
-	"github.com/momentum-xyz/ubercontroller/logger"
+	"github.com/momentum-xyz/ubercontroller/config"
 	"github.com/momentum-xyz/ubercontroller/types"
+	"go.uber.org/zap"
 )
 
 func TestMain(m *testing.M) {
-	if err := Initialize(context.WithValue(context.Background(), types.LoggerContextKey, logger.L())); err != nil {
+	cfg := &config.Config{} //TODO: proper test config getter
+	ctx, err := types.NewNodeContext(
+		context.Background(),
+		zap.NewExample().Sugar(),
+		cfg,
+	)
+	if err != nil {
+		fmt.Printf("Failed to create context: %s", err)
+		os.Exit(1)
+	}
+	if err := Initialize(ctx); err != nil {
+		fmt.Printf("Failed to initialize: %s", err)
 		os.Exit(1)
 	}
 

--- a/types/generic/generic.go
+++ b/types/generic/generic.go
@@ -2,23 +2,23 @@ package generic
 
 import (
 	"context"
+	"errors"
 
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
 	"github.com/momentum-xyz/ubercontroller/types"
-	"github.com/momentum-xyz/ubercontroller/utils"
 )
 
+// TODO: why-o-why? get rid of this global.
 var generic struct {
 	ctx context.Context
 	log *zap.SugaredLogger
 }
 
-func Initialize(ctx context.Context) error {
-	log := utils.GetFromAny(ctx.Value(types.LoggerContextKey), (*zap.SugaredLogger)(nil))
+func Initialize(ctx types.LoggerContext) error {
+	log := ctx.Logger()
 	if log == nil {
-		return errors.Errorf("failed to get logger from context: %T", ctx.Value(types.LoggerContextKey))
+		return errors.New("failed to get logger from context")
 	}
 
 	generic.ctx = ctx

--- a/types/types.go
+++ b/types/types.go
@@ -1,6 +1,1 @@
 package types
-
-const (
-	LoggerContextKey = "logger"
-	ConfigContextKey = "config"
-)

--- a/universe/asset_2d/asset_2d.go
+++ b/universe/asset_2d/asset_2d.go
@@ -1,9 +1,9 @@
 package asset_2d
 
 import (
-	"context"
-	"github.com/momentum-xyz/ubercontroller/utils/umid"
 	"sync"
+
+	"github.com/momentum-xyz/ubercontroller/utils/umid"
 
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -12,14 +12,13 @@ import (
 	"github.com/momentum-xyz/ubercontroller/types"
 	"github.com/momentum-xyz/ubercontroller/types/entry"
 	"github.com/momentum-xyz/ubercontroller/universe"
-	"github.com/momentum-xyz/ubercontroller/utils"
 	"github.com/momentum-xyz/ubercontroller/utils/modify"
 )
 
 var _ universe.Asset2d = (*Asset2d)(nil)
 
 type Asset2d struct {
-	ctx   context.Context
+	ctx   types.LoggerContext
 	log   *zap.SugaredLogger
 	db    database.DB
 	mu    sync.RWMutex
@@ -39,14 +38,9 @@ func (a *Asset2d) GetID() umid.UMID {
 	return a.entry.Asset2dID
 }
 
-func (a *Asset2d) Initialize(ctx context.Context) error {
-	log := utils.GetFromAny(ctx.Value(types.LoggerContextKey), (*zap.SugaredLogger)(nil))
-	if log == nil {
-		return errors.Errorf("failed to get logger from context: %T", ctx.Value(types.LoggerContextKey))
-	}
-
+func (a *Asset2d) Initialize(ctx types.LoggerContext) error {
 	a.ctx = ctx
-	a.log = log
+	a.log = ctx.Logger()
 
 	return nil
 }

--- a/universe/asset_3d/asset_3d.go
+++ b/universe/asset_3d/asset_3d.go
@@ -1,9 +1,9 @@
 package asset_3d
 
 import (
-	"context"
-	"github.com/momentum-xyz/ubercontroller/utils/umid"
 	"sync"
+
+	"github.com/momentum-xyz/ubercontroller/utils/umid"
 
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -12,14 +12,13 @@ import (
 	"github.com/momentum-xyz/ubercontroller/types"
 	"github.com/momentum-xyz/ubercontroller/types/entry"
 	"github.com/momentum-xyz/ubercontroller/universe"
-	"github.com/momentum-xyz/ubercontroller/utils"
 	"github.com/momentum-xyz/ubercontroller/utils/modify"
 )
 
 var _ universe.Asset3d = (*Asset3d)(nil)
 
 type Asset3d struct {
-	ctx   context.Context
+	ctx   types.LoggerContext
 	log   *zap.SugaredLogger
 	db    database.DB
 	mu    sync.RWMutex
@@ -39,14 +38,9 @@ func (a *Asset3d) GetID() umid.UMID {
 	return a.entry.Asset3dID
 }
 
-func (a *Asset3d) Initialize(ctx context.Context) error {
-	log := utils.GetFromAny(ctx.Value(types.LoggerContextKey), (*zap.SugaredLogger)(nil))
-	if log == nil {
-		return errors.Errorf("failed to get logger from context: %T", ctx.Value(types.LoggerContextKey))
-	}
-
+func (a *Asset3d) Initialize(ctx types.LoggerContext) error {
 	a.ctx = ctx
-	a.log = log
+	a.log = ctx.Logger()
 
 	return nil
 }

--- a/universe/assets_2d/api_assets_2d.go
+++ b/universe/assets_2d/api_assets_2d.go
@@ -1,12 +1,13 @@
 package assets_2d
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/momentum-xyz/ubercontroller/universe/logic/api"
 	"github.com/momentum-xyz/ubercontroller/universe/logic/api/dto"
 	"github.com/momentum-xyz/ubercontroller/utils/umid"
 	"github.com/pkg/errors"
-	"net/http"
 )
 
 // @Summary Get 2d asset
@@ -18,7 +19,7 @@ import (
 // @Param asset2dID path string true "Asset2d UMID"
 // @Success 200 {array} dto.Asset2d
 // @Failure 400 {object} api.HTTPError
-// @Router /api/v4/assets-2d [get]
+// @Router /api/v4/assets-2d/{asset2dID} [get]
 func (a *Assets2d) apiGetAsset2d(c *gin.Context) {
 	asset2dID, err := umid.Parse(c.Param("asset2dID"))
 	if err != nil {

--- a/universe/assets_2d/assets_2d.go
+++ b/universe/assets_2d/assets_2d.go
@@ -1,7 +1,6 @@
 package assets_2d
 
 import (
-	"context"
 	"github.com/momentum-xyz/ubercontroller/utils/umid"
 
 	"github.com/pkg/errors"
@@ -13,13 +12,12 @@ import (
 	"github.com/momentum-xyz/ubercontroller/types/generic"
 	"github.com/momentum-xyz/ubercontroller/universe"
 	"github.com/momentum-xyz/ubercontroller/universe/asset_2d"
-	"github.com/momentum-xyz/ubercontroller/utils"
 )
 
 var _ universe.Assets2d = (*Assets2d)(nil)
 
 type Assets2d struct {
-	ctx    context.Context
+	ctx    types.LoggerContext
 	log    *zap.SugaredLogger
 	db     database.DB
 	assets *generic.SyncMap[umid.UMID, universe.Asset2d]
@@ -32,14 +30,10 @@ func NewAssets2d(db database.DB) *Assets2d {
 	}
 }
 
-func (a *Assets2d) Initialize(ctx context.Context) error {
-	log := utils.GetFromAny(ctx.Value(types.LoggerContextKey), (*zap.SugaredLogger)(nil))
-	if log == nil {
-		return errors.Errorf("failed to get logger from context: %T", ctx.Value(types.LoggerContextKey))
-	}
+func (a *Assets2d) Initialize(ctx types.NodeContext) error {
 
 	a.ctx = ctx
-	a.log = log
+	a.log = ctx.Logger()
 
 	return nil
 }

--- a/universe/assets_3d/api_assets_3d.go
+++ b/universe/assets_3d/api_assets_3d.go
@@ -2,11 +2,12 @@ package assets_3d
 
 import (
 	"encoding/json"
-	"github.com/momentum-xyz/ubercontroller/utils/umid"
 	"mime/multipart"
 	"net/http"
 	"path/filepath"
 	"time"
+
+	"github.com/momentum-xyz/ubercontroller/utils/umid"
 
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
@@ -87,7 +88,7 @@ func (a *Assets3d) apiGetAssets3d(c *gin.Context) {
 // @Success 200 {object} nil
 // @Failure 400	{object} api.HTTPError
 // @Failure 500 {object} api.HTTPError
-// @Router /api/v4/assets-3d/{object_id} [post]
+// @Router /api/v4/assets-3d [post]
 func (a *Assets3d) apiAddAssets3d(c *gin.Context) {
 	type InBody struct {
 		Assets3dIDs []string `form:"assets3d_ids[]" binding:"required"`
@@ -258,7 +259,7 @@ func (a *Assets3d) apiUploadAsset3d(c *gin.Context) {
 // @Success 200 {object} nil
 // @Failure 400 {object} api.HTTPError
 // @Failure 500 {object} api.HTTPError
-// @Router /api/v4/assets-3d/{object_id} [delete]
+// @Router /api/v4/assets-3d [delete]
 func (a *Assets3d) apiRemoveAssets3dByIDs(c *gin.Context) {
 	type InBody struct {
 		Assets3dIDs []string `form:"assets3d_ids[]" binding:"required"`
@@ -395,9 +396,10 @@ func (a *Assets3d) apiGetAssets3dMeta(c *gin.Context) {
 // @Tags assets3d
 // @Accept json
 // @Produce json
+// @Param asset3dID path string true "Asset3D UMID"
 // @Success 200 {object} nil
 // @Failure 500 {object} api.HTTPError
-// @Router /api/v4/assets-3d/{object_id}/{asset3d_id} [delete]
+// @Router /api/v4/assets-3d/{asset3dID} [delete]
 func (a *Assets3d) apiRemoveAsset3dByID(c *gin.Context) {
 	uid, err := umid.Parse(c.Param("asset3dID"))
 	if err != nil {

--- a/universe/assets_3d/assets_3d.go
+++ b/universe/assets_3d/assets_3d.go
@@ -1,7 +1,6 @@
 package assets_3d
 
 import (
-	"context"
 	"github.com/momentum-xyz/ubercontroller/utils/umid"
 
 	"github.com/pkg/errors"
@@ -14,13 +13,12 @@ import (
 	"github.com/momentum-xyz/ubercontroller/types/generic"
 	"github.com/momentum-xyz/ubercontroller/universe"
 	"github.com/momentum-xyz/ubercontroller/universe/asset_3d"
-	"github.com/momentum-xyz/ubercontroller/utils"
 )
 
 var _ universe.Assets3d = (*Assets3d)(nil)
 
 type Assets3d struct {
-	ctx    context.Context
+	ctx    types.LoggerContext
 	log    *zap.SugaredLogger
 	cfg    *config.Config
 	db     database.DB
@@ -34,20 +32,10 @@ func NewAssets3d(db database.DB) *Assets3d {
 	}
 }
 
-func (a *Assets3d) Initialize(ctx context.Context) error {
-	log := utils.GetFromAny(ctx.Value(types.LoggerContextKey), (*zap.SugaredLogger)(nil))
-	if log == nil {
-		return errors.Errorf("failed to get logger from context: %T", ctx.Value(types.LoggerContextKey))
-	}
-
-	cfg := utils.GetFromAny(ctx.Value(types.ConfigContextKey), (*config.Config)(nil))
-	if cfg == nil {
-		return errors.Errorf("failed to get config from context: %T", ctx.Value(types.ConfigContextKey))
-	}
-
+func (a *Assets3d) Initialize(ctx types.NodeContext) error {
 	a.ctx = ctx
-	a.log = log
-	a.cfg = cfg
+	a.log = ctx.Logger()
+	a.cfg = ctx.Config()
 
 	return nil
 }

--- a/universe/attribute_type/attribute_type.go
+++ b/universe/attribute_type/attribute_type.go
@@ -2,8 +2,9 @@ package attribute_type
 
 import (
 	"context"
-	"github.com/momentum-xyz/ubercontroller/utils/umid"
 	"sync"
+
+	"github.com/momentum-xyz/ubercontroller/utils/umid"
 
 	"github.com/momentum-xyz/ubercontroller/universe"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/momentum-xyz/ubercontroller/database"
 	"github.com/momentum-xyz/ubercontroller/types"
 	"github.com/momentum-xyz/ubercontroller/types/entry"
-	"github.com/momentum-xyz/ubercontroller/utils"
 	"github.com/momentum-xyz/ubercontroller/utils/modify"
 )
 
@@ -38,14 +38,10 @@ func NewAttributeType(id entry.AttributeTypeID, db database.DB) *AttributeType {
 	}
 }
 
-func (a *AttributeType) Initialize(ctx context.Context) error {
-	log := utils.GetFromAny(ctx.Value(types.LoggerContextKey), (*zap.SugaredLogger)(nil))
-	if log == nil {
-		return errors.Errorf("failed to get logger from context: %T", ctx.Value(types.LoggerContextKey))
-	}
+func (a *AttributeType) Initialize(ctx types.LoggerContext) error {
 
 	a.ctx = ctx
-	a.log = log
+	a.log = ctx.Logger()
 
 	return nil
 }

--- a/universe/attribute_types/attribute_types.go
+++ b/universe/attribute_types/attribute_types.go
@@ -1,8 +1,6 @@
 package attribute_types
 
 import (
-	"context"
-
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
@@ -12,13 +10,12 @@ import (
 	"github.com/momentum-xyz/ubercontroller/types/generic"
 	"github.com/momentum-xyz/ubercontroller/universe"
 	"github.com/momentum-xyz/ubercontroller/universe/attribute_type"
-	"github.com/momentum-xyz/ubercontroller/utils"
 )
 
 var _ universe.AttributeTypes = (*AttributeTypes)(nil)
 
 type AttributeTypes struct {
-	ctx            context.Context
+	ctx            types.LoggerContext
 	log            *zap.SugaredLogger
 	db             database.DB
 	attributeTypes *generic.SyncMap[entry.AttributeTypeID, universe.AttributeType]
@@ -31,14 +28,9 @@ func NewAttributeTypes(db database.DB) *AttributeTypes {
 	}
 }
 
-func (a *AttributeTypes) Initialize(ctx context.Context) error {
-	log := utils.GetFromAny(ctx.Value(types.LoggerContextKey), (*zap.SugaredLogger)(nil))
-	if log == nil {
-		return errors.Errorf("failed to get logger from context: %T", ctx.Value(types.LoggerContextKey))
-	}
-
+func (a *AttributeTypes) Initialize(ctx types.LoggerContext) error {
 	a.ctx = ctx
-	a.log = log
+	a.log = ctx.Logger()
 
 	return nil
 }

--- a/universe/interfaces.go
+++ b/universe/interfaces.go
@@ -7,8 +7,11 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 	influxWrite "github.com/influxdata/influxdb-client-go/v2/api/write"
+	"go.uber.org/zap"
 
+	"github.com/momentum-xyz/ubercontroller/config"
 	"github.com/momentum-xyz/ubercontroller/pkg/posbus"
+	"github.com/momentum-xyz/ubercontroller/types"
 	"github.com/momentum-xyz/ubercontroller/utils/umid"
 
 	"github.com/momentum-xyz/ubercontroller/pkg/cmath"
@@ -21,7 +24,7 @@ type IDer interface {
 }
 
 type Initializer interface {
-	Initialize(ctx context.Context) error
+	Initialize(ctx types.NodeContext) error
 }
 
 type Enabler interface {
@@ -77,6 +80,9 @@ type Node interface {
 	APIRegister
 	ObjectsCacher
 
+	GetConfig() *config.Config
+	GetLogger() *zap.SugaredLogger
+
 	ToObject() Object
 
 	GetWorlds() Worlds
@@ -105,7 +111,6 @@ type Node interface {
 }
 
 type Worlds interface {
-	Initializer
 	RunStopper
 	LoadSaver
 	APIRegister
@@ -221,7 +226,6 @@ type Object interface {
 
 type User interface {
 	IDer
-	Initializer
 	RunStopper
 
 	GetWorld() World
@@ -352,7 +356,6 @@ type ObjectUserAttributes interface {
 }
 
 type Assets2d interface {
-	Initializer
 	LoadSaver
 	APIRegister
 
@@ -368,7 +371,6 @@ type Assets2d interface {
 
 type Asset2d interface {
 	IDer
-	Initializer
 
 	GetMeta() entry.Asset2dMeta
 	SetMeta(meta entry.Asset2dMeta, updateDB bool) error
@@ -381,7 +383,6 @@ type Asset2d interface {
 }
 
 type Assets3d interface {
-	Initializer
 	LoadSaver
 	APIRegister
 
@@ -399,8 +400,6 @@ type Assets3d interface {
 
 type Asset3d interface {
 	IDer
-	Initializer
-
 	GetMeta() *entry.Asset3dMeta
 	SetMeta(meta *entry.Asset3dMeta, updateDB bool) error
 
@@ -412,7 +411,6 @@ type Asset3d interface {
 }
 
 type Plugins interface {
-	Initializer
 	LoadSaver
 	APIRegister
 
@@ -428,7 +426,6 @@ type Plugins interface {
 
 type Plugin interface {
 	IDer
-	Initializer
 
 	GetMeta() entry.PluginMeta
 	SetMeta(meta entry.PluginMeta, updateDB bool) error
@@ -441,7 +438,6 @@ type Plugin interface {
 }
 
 type AttributeTypes interface {
-	Initializer
 	LoadSaver
 	APIRegister
 
@@ -456,8 +452,6 @@ type AttributeTypes interface {
 }
 
 type AttributeType interface {
-	Initializer
-
 	GetID() entry.AttributeTypeID
 	GetName() string
 	GetPluginID() umid.UMID
@@ -473,7 +467,6 @@ type AttributeType interface {
 }
 
 type ObjectTypes interface {
-	Initializer
 	LoadSaver
 	APIRegister
 
@@ -489,7 +482,6 @@ type ObjectTypes interface {
 
 type ObjectType interface {
 	IDer
-	Initializer
 
 	GetName() string
 	SetName(name string, updateDB bool) error
@@ -514,7 +506,6 @@ type ObjectType interface {
 }
 
 type UserTypes interface {
-	Initializer
 	LoadSaver
 	APIRegister
 
@@ -530,7 +521,6 @@ type UserTypes interface {
 
 type UserType interface {
 	IDer
-	Initializer
 
 	GetName() string
 	SetName(name string, updateDB bool) error
@@ -546,7 +536,6 @@ type UserType interface {
 }
 
 type Calendar interface {
-	Initializer
 	RunStopper
 
 	OnAttributeUpsert(attributeID entry.AttributeID, value any)

--- a/universe/iot/iot.go
+++ b/universe/iot/iot.go
@@ -3,16 +3,16 @@ package iot
 import (
 	"context"
 	"encoding/json"
+	"reflect"
+	"time"
+
 	"github.com/gorilla/websocket"
 	"github.com/momentum-xyz/ubercontroller/pkg/cmath"
 	"github.com/momentum-xyz/ubercontroller/types"
 	"github.com/momentum-xyz/ubercontroller/universe"
-	"github.com/momentum-xyz/ubercontroller/utils"
 	"github.com/momentum-xyz/ubercontroller/utils/umid"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
-	"reflect"
-	"time"
 )
 
 const (
@@ -46,16 +46,12 @@ type IOTWorker struct {
 	cubey universe.Object
 }
 
-func NewIOTWorker(ws *websocket.Conn, ctx context.Context) *IOTWorker {
+func NewIOTWorker(ws *websocket.Conn, ctx types.LoggerContext) *IOTWorker {
 
 	iw := IOTWorker{ws: ws}
-	log := utils.GetFromAny(ctx.Value(types.LoggerContextKey), (*zap.SugaredLogger)(nil))
-	if log == nil {
-		return nil
-	}
 
 	iw.ctx = ctx
-	iw.log = log
+	iw.log = ctx.Logger()
 	iw.send = make(chan *websocket.PreparedMessage, 10)
 	iw.world, _ = universe.GetNode().GetWorlds().GetWorld(umid.MustParse("4ecdc743-150e-466a-983f-011e0aa2f116"))
 	iw.cubey, _ = iw.world.GetObject(umid.MustParse("12741349-98a6-4c56-847d-86c4af4fc38f"), true)

--- a/universe/logic/common/slot/options_auto.go
+++ b/universe/logic/common/slot/options_auto.go
@@ -2,13 +2,11 @@ package slot
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"net/http"
 	"strconv"
 	"strings"
 
-	"github.com/momentum-xyz/ubercontroller/config"
 	"github.com/momentum-xyz/ubercontroller/types"
 	"github.com/momentum-xyz/ubercontroller/types/entry"
 	"github.com/momentum-xyz/ubercontroller/universe/logic/api/dto"
@@ -71,7 +69,7 @@ func GetOptionAutoOption(
 }
 
 func PrerenderAutoValue(
-	ctx context.Context, option *entry.RenderAutoAttributeOption, value *entry.AttributeValue,
+	ctx types.ConfigContext, option *entry.RenderAutoAttributeOption, value *entry.AttributeValue,
 ) (*dto.HashResponse, error) {
 	if option == nil || option.SlotType != "texture" || value == nil {
 		return nil, nil
@@ -141,12 +139,9 @@ func PrerenderAutoValue(
 	return hash, nil
 }
 
-func renderFrame(ctx context.Context, textJob []byte) (*dto.HashResponse, error) {
+func renderFrame(ctx types.ConfigContext, textJob []byte) (*dto.HashResponse, error) {
 	// need config for the media-manager render URLs
-	cfg := utils.GetFromAny(ctx.Value(types.ConfigContextKey), (*config.Config)(nil))
-	if cfg == nil {
-		return nil, errors.Errorf("failed to get config from context: %T", ctx.Value(types.ConfigContextKey))
-	}
+	cfg := ctx.Config()
 
 	req, err := http.NewRequest("POST", cfg.Common.RenderInternalURL+"/render/addframe", bytes.NewBuffer(textJob))
 	if err != nil {
@@ -173,12 +168,9 @@ func renderFrame(ctx context.Context, textJob []byte) (*dto.HashResponse, error)
 	return response, nil
 }
 
-func renderVideo(ctx context.Context, url []byte) (*dto.HashResponse, error) {
+func renderVideo(ctx types.ConfigContext, url []byte) (*dto.HashResponse, error) {
 	// need config for the media-manager render URLs
-	cfg := utils.GetFromAny(ctx.Value(types.ConfigContextKey), (*config.Config)(nil))
-	if cfg == nil {
-		return nil, errors.Errorf("failed to get config from context: %T", ctx.Value(types.ConfigContextKey))
-	}
+	cfg := ctx.Config()
 
 	req, err := http.NewRequest("POST", cfg.Common.RenderInternalURL+"/render/addtube", bytes.NewBuffer(url))
 	if err != nil {

--- a/universe/logic/logic.go
+++ b/universe/logic/logic.go
@@ -2,10 +2,10 @@ package logic
 
 import (
 	"context"
+	"errors"
+
 	"github.com/momentum-xyz/ubercontroller/config"
 	"github.com/momentum-xyz/ubercontroller/types"
-	"github.com/momentum-xyz/ubercontroller/utils"
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -15,14 +15,18 @@ var logic struct {
 	cfg *config.Config
 }
 
-func Initialize(ctx context.Context) error {
-	log := utils.GetFromAny(ctx.Value(types.LoggerContextKey), (*zap.SugaredLogger)(nil))
+func Initialize(ctx interface {
+	context.Context
+	types.LoggerContext
+	types.ConfigContext
+}) error {
+	log := ctx.Logger()
 	if log == nil {
-		return errors.Errorf("failed to get logger from context: %T", ctx.Value(types.LoggerContextKey))
+		return errors.New("failed to get logger from context")
 	}
-	cfg := utils.GetFromAny(ctx.Value(types.ConfigContextKey), (*config.Config)(nil))
+	cfg := ctx.Config()
 	if cfg == nil {
-		return errors.Errorf("failed to get config from context: %T", ctx.Value(types.ConfigContextKey))
+		return errors.New("failed to get config from context")
 	}
 
 	logic.ctx = ctx

--- a/universe/object/object.go
+++ b/universe/object/object.go
@@ -1,7 +1,6 @@
 package object
 
 import (
-	"context"
 	"sync/atomic"
 	"time"
 
@@ -33,7 +32,7 @@ var _ universe.Object = (*Object)(nil)
 type Object struct {
 	id       umid.UMID
 	world    universe.World
-	ctx      context.Context
+	ctx      types.NodeContext
 	log      *zap.SugaredLogger
 	CFG      *config.Config
 	db       database.DB
@@ -145,19 +144,10 @@ func (o *Object) GetObjectAttributes() universe.ObjectAttributes {
 	return o.objectAttributes
 }
 
-func (o *Object) Initialize(ctx context.Context) error {
-	log := utils.GetFromAny(ctx.Value(types.LoggerContextKey), (*zap.SugaredLogger)(nil))
-	if log == nil {
-		return errors.Errorf("failed to get logger from context: %T", ctx.Value(types.LoggerContextKey))
-	}
-	cfg := utils.GetFromAny(ctx.Value(types.ConfigContextKey), (*config.Config)(nil))
-	if cfg == nil {
-		return errors.Errorf("failed to get config from context: %T", ctx.Value(types.ConfigContextKey))
-	}
-
+func (o *Object) Initialize(ctx types.NodeContext) error {
 	o.ctx = ctx
-	o.log = log
-	o.CFG = cfg
+	o.log = ctx.Logger()
+	o.CFG = ctx.Config()
 	o.numSendsQueued.Store(chanIsClosed)
 	o.lockedBy.Store(umid.Nil)
 

--- a/universe/object_type/object_type.go
+++ b/universe/object_type/object_type.go
@@ -2,8 +2,9 @@ package object_type
 
 import (
 	"context"
-	"github.com/momentum-xyz/ubercontroller/utils/umid"
 	"sync"
+
+	"github.com/momentum-xyz/ubercontroller/utils/umid"
 
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -50,14 +51,9 @@ func (ot *ObjectType) GetID() umid.UMID {
 	return ot.id
 }
 
-func (ot *ObjectType) Initialize(ctx context.Context) error {
-	log := utils.GetFromAny(ctx.Value(types.LoggerContextKey), (*zap.SugaredLogger)(nil))
-	if log == nil {
-		return errors.Errorf("failed to get logger from context: %T", ctx.Value(types.LoggerContextKey))
-	}
-
+func (ot *ObjectType) Initialize(ctx types.LoggerContext) error {
 	ot.ctx = ctx
-	ot.log = log
+	ot.log = ctx.Logger()
 
 	return nil
 }

--- a/universe/object_types/object_types.go
+++ b/universe/object_types/object_types.go
@@ -1,7 +1,6 @@
 package object_types
 
 import (
-	"context"
 	"github.com/momentum-xyz/ubercontroller/utils/umid"
 
 	"github.com/pkg/errors"
@@ -13,13 +12,12 @@ import (
 	"github.com/momentum-xyz/ubercontroller/types/generic"
 	"github.com/momentum-xyz/ubercontroller/universe"
 	"github.com/momentum-xyz/ubercontroller/universe/object_type"
-	"github.com/momentum-xyz/ubercontroller/utils"
 )
 
 var _ universe.ObjectTypes = (*ObjectTypes)(nil)
 
 type ObjectTypes struct {
-	ctx         context.Context
+	ctx         types.LoggerContext
 	log         *zap.SugaredLogger
 	db          database.DB
 	objectTypes *generic.SyncMap[umid.UMID, universe.ObjectType]
@@ -32,14 +30,9 @@ func NewObjectTypes(db database.DB) *ObjectTypes {
 	}
 }
 
-func (ot *ObjectTypes) Initialize(ctx context.Context) error {
-	log := utils.GetFromAny(ctx.Value(types.LoggerContextKey), (*zap.SugaredLogger)(nil))
-	if log == nil {
-		return errors.Errorf("failed to get logger from context: %T", ctx.Value(types.LoggerContextKey))
-	}
-
+func (ot *ObjectTypes) Initialize(ctx types.LoggerContext) error {
 	ot.ctx = ctx
-	ot.log = log
+	ot.log = ctx.Logger()
 
 	return nil
 }

--- a/universe/plugin/plugin.go
+++ b/universe/plugin/plugin.go
@@ -2,9 +2,10 @@ package plugin
 
 import (
 	"context"
-	"github.com/momentum-xyz/ubercontroller/utils/umid"
 	"plugin"
 	"sync"
+
+	"github.com/momentum-xyz/ubercontroller/utils/umid"
 
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -42,14 +43,9 @@ func NewPlugin(id umid.UMID, db database.DB) *Plugin {
 	}
 }
 
-func (p *Plugin) Initialize(ctx context.Context) error {
-	log := utils.GetFromAny(ctx.Value(types.LoggerContextKey), (*zap.SugaredLogger)(nil))
-	if log == nil {
-		return errors.Errorf("failed to get logger from context: %T", ctx.Value(types.LoggerContextKey))
-	}
-
+func (p *Plugin) Initialize(ctx types.LoggerContext) error {
 	p.ctx = ctx
-	p.log = log
+	p.log = ctx.Logger()
 
 	return nil
 }

--- a/universe/plugins/plugins.go
+++ b/universe/plugins/plugins.go
@@ -1,7 +1,6 @@
 package plugins
 
 import (
-	"context"
 	"github.com/momentum-xyz/ubercontroller/utils/umid"
 
 	"golang.org/x/sync/errgroup"
@@ -15,13 +14,12 @@ import (
 	"github.com/momentum-xyz/ubercontroller/types/generic"
 	"github.com/momentum-xyz/ubercontroller/universe"
 	"github.com/momentum-xyz/ubercontroller/universe/plugin"
-	"github.com/momentum-xyz/ubercontroller/utils"
 )
 
 var _ universe.Plugins = (*Plugins)(nil)
 
 type Plugins struct {
-	ctx     context.Context
+	ctx     types.LoggerContext
 	log     *zap.SugaredLogger
 	db      database.DB
 	plugins *generic.SyncMap[umid.UMID, universe.Plugin]
@@ -34,14 +32,9 @@ func NewPlugins(db database.DB) *Plugins {
 	}
 }
 
-func (p *Plugins) Initialize(ctx context.Context) error {
-	log := utils.GetFromAny(ctx.Value(types.LoggerContextKey), (*zap.SugaredLogger)(nil))
-	if log == nil {
-		return errors.Errorf("failed to get logger from context: %T", ctx.Value(types.LoggerContextKey))
-	}
-
+func (p *Plugins) Initialize(ctx types.LoggerContext) error {
 	p.ctx = ctx
-	p.log = log
+	p.log = ctx.Logger()
 
 	return nil
 }

--- a/universe/streamchat/streamchat.go
+++ b/universe/streamchat/streamchat.go
@@ -7,11 +7,8 @@ import (
 	"time"
 
 	stream "github.com/GetStream/stream-chat-go/v6"
-	"github.com/momentum-xyz/ubercontroller/config"
 	"github.com/momentum-xyz/ubercontroller/types"
 	"github.com/momentum-xyz/ubercontroller/universe"
-	"github.com/momentum-xyz/ubercontroller/utils"
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"golang.org/x/net/context"
 )
@@ -35,21 +32,14 @@ func NewStreamChat() *StreamChat {
 	return &StreamChat{}
 }
 
-func (s *StreamChat) Initialize(ctx context.Context) error {
-	log := utils.GetFromAny(ctx.Value(types.LoggerContextKey), (*zap.SugaredLogger)(nil))
-	if log == nil {
-		return errors.Errorf("failed to get logger from context: %T", ctx.Value(types.LoggerContextKey))
-	}
-	cfg := utils.GetFromAny(ctx.Value(types.ConfigContextKey), (*config.Config)(nil))
-	if cfg == nil {
-		return errors.Errorf("failed to get config from context: %T", ctx.Value(types.ConfigContextKey))
-	}
+func (s *StreamChat) Initialize(ctx types.NodeContext) error {
+	cfg := ctx.Config()
 	apiKey := cfg.Streamchat.APIKey
 	apiSecret := cfg.Streamchat.APISecret
 
 	s.node = universe.GetNode()
 	s.ctx = ctx
-	s.log = log
+	s.log = ctx.Logger()
 	s.apiKey = apiKey
 	s.apiSecret = apiSecret
 	return nil

--- a/universe/user/user.go
+++ b/universe/user/user.go
@@ -22,7 +22,6 @@ import (
 	"github.com/momentum-xyz/ubercontroller/types"
 	"github.com/momentum-xyz/ubercontroller/types/entry"
 	"github.com/momentum-xyz/ubercontroller/universe"
-	"github.com/momentum-xyz/ubercontroller/utils"
 )
 
 var _ universe.User = (*User)(nil)
@@ -200,14 +199,9 @@ func (u *User) GetProfile() *entry.UserProfile {
 	return u.profile
 }
 
-func (u *User) Initialize(ctx context.Context) error {
-	log := utils.GetFromAny(ctx.Value(types.LoggerContextKey), (*zap.SugaredLogger)(nil))
-	if log == nil {
-		return errors.Errorf("failed to get logger from context: %T", ctx.Value(types.LoggerContextKey))
-	}
-
+func (u *User) Initialize(ctx types.LoggerContext) error {
 	u.ctx = ctx
-	u.log = log
+	u.log = ctx.Logger()
 	u.bufferSends.Store(true)
 	u.numSendsQueued.Store(chanIsClosed)
 	//u.posMsgBuffer = posbus.NewSendTransformBuffer(u.GetID())

--- a/universe/user_type/user_type.go
+++ b/universe/user_type/user_type.go
@@ -2,8 +2,9 @@ package user_type
 
 import (
 	"context"
-	"github.com/momentum-xyz/ubercontroller/utils/umid"
 	"sync"
+
+	"github.com/momentum-xyz/ubercontroller/utils/umid"
 
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -43,14 +44,9 @@ func (u *UserType) GetID() umid.UMID {
 	return u.id
 }
 
-func (u *UserType) Initialize(ctx context.Context) error {
-	log := utils.GetFromAny(ctx.Value(types.LoggerContextKey), (*zap.SugaredLogger)(nil))
-	if log == nil {
-		return errors.Errorf("failed to get logger from context: %T", ctx.Value(types.LoggerContextKey))
-	}
-
+func (u *UserType) Initialize(ctx types.LoggerContext) error {
 	u.ctx = ctx
-	u.log = log
+	u.log = ctx.Logger()
 
 	return nil
 }

--- a/universe/user_types/user_types.go
+++ b/universe/user_types/user_types.go
@@ -1,7 +1,6 @@
 package user_types
 
 import (
-	"context"
 	"github.com/momentum-xyz/ubercontroller/utils/umid"
 
 	"github.com/pkg/errors"
@@ -13,13 +12,12 @@ import (
 	"github.com/momentum-xyz/ubercontroller/types/generic"
 	"github.com/momentum-xyz/ubercontroller/universe"
 	"github.com/momentum-xyz/ubercontroller/universe/user_type"
-	"github.com/momentum-xyz/ubercontroller/utils"
 )
 
 var _ universe.UserTypes = (*UserTypes)(nil)
 
 type UserTypes struct {
-	ctx       context.Context
+	ctx       types.LoggerContext
 	log       *zap.SugaredLogger
 	db        database.DB
 	userTypes *generic.SyncMap[umid.UMID, universe.UserType]
@@ -32,14 +30,9 @@ func NewUserTypes(db database.DB) *UserTypes {
 	}
 }
 
-func (u *UserTypes) Initialize(ctx context.Context) error {
-	log := utils.GetFromAny(ctx.Value(types.LoggerContextKey), (*zap.SugaredLogger)(nil))
-	if log == nil {
-		return errors.Errorf("failed to get logger from context: %T", ctx.Value(types.LoggerContextKey))
-	}
-
+func (u *UserTypes) Initialize(ctx types.LoggerContext) error {
 	u.ctx = ctx
-	u.log = log
+	u.log = ctx.Logger()
 
 	return nil
 }

--- a/universe/world/world.go
+++ b/universe/world/world.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
-	"github.com/momentum-xyz/ubercontroller/config"
 	"github.com/momentum-xyz/ubercontroller/database"
 	"github.com/momentum-xyz/ubercontroller/mplugin"
 	"github.com/momentum-xyz/ubercontroller/types"
@@ -110,18 +109,9 @@ func (w *World) corePluginInitFunc(pi mplugin.PluginInterface) (mplugin.PluginIn
 	return instance, nil
 }
 
-func (w *World) Initialize(ctx context.Context) error {
-	log := utils.GetFromAny(ctx.Value(types.LoggerContextKey), (*zap.SugaredLogger)(nil))
-	if log == nil {
-		return errors.Errorf("failed to get logger from context: %T", ctx.Value(types.LoggerContextKey))
-	}
-	cfg := utils.GetFromAny(ctx.Value(types.ConfigContextKey), (*config.Config)(nil))
-	if cfg == nil {
-		return errors.Errorf("failed to get config from context: %T", ctx.Value(types.ConfigContextKey))
-	}
-
+func (w *World) Initialize(ctx types.NodeContext) error {
 	w.ctx, w.cancel = context.WithCancel(ctx)
-	w.log = log
+	w.log = ctx.Logger()
 
 	if err := w.calendar.Initialize(ctx); err != nil {
 		return errors.WithMessage(err, "failed to initialize calendar")

--- a/universe/worlds/worlds.go
+++ b/universe/worlds/worlds.go
@@ -1,8 +1,6 @@
 package worlds
 
 import (
-	"context"
-
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -13,14 +11,13 @@ import (
 	"github.com/momentum-xyz/ubercontroller/types/generic"
 	"github.com/momentum-xyz/ubercontroller/universe"
 	"github.com/momentum-xyz/ubercontroller/universe/world"
-	"github.com/momentum-xyz/ubercontroller/utils"
 	"github.com/momentum-xyz/ubercontroller/utils/umid"
 )
 
 var _ universe.Worlds = (*Worlds)(nil)
 
 type Worlds struct {
-	ctx    context.Context
+	ctx    types.NodeContext
 	log    *zap.SugaredLogger
 	cfg    *config.Config
 	db     database.DB
@@ -34,19 +31,10 @@ func NewWorlds(db database.DB) *Worlds {
 	}
 }
 
-func (w *Worlds) Initialize(ctx context.Context) error {
-	log := utils.GetFromAny(ctx.Value(types.LoggerContextKey), (*zap.SugaredLogger)(nil))
-	if log == nil {
-		return errors.Errorf("failed to get logger from context: %T", ctx.Value(types.LoggerContextKey))
-	}
-	cfg := utils.GetFromAny(ctx.Value(types.ConfigContextKey), (*config.Config)(nil))
-	if cfg == nil {
-		return errors.Errorf("failed to get config from context: %T", ctx.Value(types.ConfigContextKey))
-	}
-
+func (w *Worlds) Initialize(ctx types.NodeContext) error {
 	w.ctx = ctx
-	w.log = log
-	w.cfg = cfg
+	w.log = ctx.Logger()
+	w.cfg = ctx.Config()
 
 	return nil
 }


### PR DESCRIPTION
Ran into some issues multiple times now, when trying to add test and get better log messages. So started a bit of refactoring.

The 'global' context usage (putting them inside structs) make it harder to do automated testing (since ctx can not be reused after they have been stopped) and using structured, leveled logging. So as a first step, this change makes it more explicit where they are used (so in a next step, ctx could be refactored to not be used in 'initialization' at all and loggers could be configured on structs).


