### PR TITLE
feat(seed): allow running only the seeder

### DIFF
--- a/cmd/service/main.go
+++ b/cmd/service/main.go
@@ -2,7 +2,8 @@ package main
 
 import (
 	"context"
-	"fmt"
+	"flag"
+	"log"
 	"math/rand"
 	"os"
 	"os/signal"
@@ -22,11 +23,20 @@ import (
 var version = "devel"
 
 func main() {
+	seedOnly := flag.Bool("seed", false, "Only seed the database.")
+	flag.Parse()
+
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	if err := run(ctx); err != nil {
-		fmt.Printf("Failed to run service: %v", err)
+	if *seedOnly {
+		if err := runSeeder(ctx); err != nil {
+			log.Fatal(errors.WithMessage(err, "failed to run seeder"))
+		}
+	} else {
+		if err := run(ctx); err != nil {
+			log.Fatal(errors.WithMessage(err, "failed to run service"))
+		}
 	}
 }
 
@@ -78,5 +88,34 @@ func run(ctx context.Context) error {
 	cute.SetMessageColor(cute.BrightBlue)
 	cute.Println("Node stopped", "That's all folks!")
 
+	return nil
+}
+
+func runSeeder(ctx context.Context) error {
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return errors.WithMessage(err, "failed to get config")
+	}
+	log := logger.L()
+	log.Debugf("Version: %s", version)
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	nodeCtx, err := types.NewNodeContext(ctx, log, cfg)
+	if err != nil {
+		return errors.WithMessage(err, "failed to create context")
+	}
+	pool, err := service.CreateDBConnection(nodeCtx, &cfg.Postgres)
+	if err != nil {
+		return errors.WithMessage(err, "failed to create db connection")
+	}
+	defer pool.Close()
+
+	log.Debug("Seed node.")
+	err = service.SeedNode(nodeCtx, cfg, pool)
+	if err != nil {
+		return errors.WithMessage(err, "failed to seed nope")
+	}
+	log.Debug("Seeded node.")
 	return nil
 }


### PR DESCRIPTION
Can now run the controller executable with `-seed` to only run the seeder. 
What it then exactly does is undefined ;) 
It won't check if the database already exists, just blindly run the code
Mostly for development and testing... of reseeding a database :)