### PR TITLE
Posbus: fix SkyboxAI Status attribute change

### DIFF
--- a/pkg/posbus/string_map_base.go
+++ b/pkg/posbus/string_map_base.go
@@ -7,8 +7,13 @@ import (
 func init() {
 	// workaround, sometimes when receiving StringAnyMap, we end up in the 'interface' branch of gotiny unmarshalling and not the map handling :/
 	// Needs some more debugging. But for now avoid the panic when handling these.
-	gotiny.Register("")
+	str := ""
+	gotiny.Register(str)
+	gotiny.Register(&str)
 	gotiny.Register(true)
+	num := 42
+	gotiny.Register(num)
+	gotiny.Register(&num)
 	gotiny.Register(float64(42))
 	gotiny.Register([]any{})
 	gotiny.Register(map[string]any{})

--- a/universe/node/api_skybox.go
+++ b/universe/node/api_skybox.go
@@ -261,9 +261,6 @@ func (n *Node) apiPostSkyboxGenerate(c *gin.Context) {
 	skyboxIDToUserID[response.Id] = userID
 	skyboxIDToWorldID[response.Id] = inBody.WorldID
 
-	m := make(entry.AttributeValue)
-	m[response.ObfuscatedId] = response
-
 	var modifyFunc modify.Fn[entry.AttributePayload]
 	modifyFunc = func(payload *entry.AttributePayload) (*entry.AttributePayload, error) {
 		if payload == nil {

--- a/universe/node/api_skybox.go
+++ b/universe/node/api_skybox.go
@@ -273,7 +273,11 @@ func (n *Node) apiPostSkyboxGenerate(c *gin.Context) {
 			}
 		}
 		val := *payload.Value
-		val[strconv.Itoa(response.Id)] = response
+
+		var mp map[string]any
+		utils.MapEncode(response, &mp)
+
+		val[strconv.Itoa(response.Id)] = mp
 
 		return payload, nil
 	}
@@ -337,7 +341,11 @@ func (n *Node) apiPostSkyboxWebHook(c *gin.Context) {
 	var modifyFunc modify.Fn[entry.AttributePayload]
 	modifyFunc = func(payload *entry.AttributePayload) (*entry.AttributePayload, error) {
 		val := *payload.Value
-		val[strconv.Itoa(inBody.Id)] = inBody
+
+		var mp map[string]any
+		utils.MapEncode(inBody, &mp)
+
+		val[strconv.Itoa(inBody.Id)] = mp
 
 		return payload, nil
 	}


### PR DESCRIPTION
I had an issue decoding posbus messages in UI-client after skybox status update is stored in attribute.

First it was 

```
failed to decode message, head=[]byte{0xb7, 0xcd, 0xda, 0x10, 0xf0, 0xf0, 0xf0, 0xf0} (total len=3350): panic decoding Message: unknown typ: ...node.SkyboxStatus
```
which I fixed by @jor-rit advice by converting to `map[string]any`.
It helped as I proceeded to new error:

```
failed to decode message, head=[]byte{0xb7, 0xcd, 0xda, 0x10, 0xf0, 0xf0, 0xf0, 0xf0} (total len=3350): panic decoding Message: unknown typ:int
```

Turned out there's some workaround for gotiny marshal/unmarshal that leads to breaking decoding of map, having int. It works with float and string. Doesn't with `*string` though. So I added exceptions for those as well.

It's still a workaround, don't have a proper solution for now.