### PR TITLE
feat(posbus): object_type_id parameter in object_definition

### DIFF
--- a/pkg/posbus/ObjectDefinition.mus.go
+++ b/pkg/posbus/ObjectDefinition.mus.go
@@ -21,6 +21,10 @@ func (v ObjectDefinition) MarshalMUS(buf []byte) int {
 		i += si
 	}
 	{
+		si := v.ObjectTypeID.MarshalMUS(buf[i:])
+		i += si
+	}
+	{
 		si := v.AssetType.MarshalMUS(buf[i:])
 		i += si
 	}
@@ -110,6 +114,18 @@ func (v *ObjectDefinition) UnmarshalMUS(buf []byte) (int, error) {
 	}
 	if err != nil {
 		return i, muserrs.NewFieldError("ParentID", err)
+	}
+	{
+		var sv umid.UMID
+		si := 0
+		si, err = sv.UnmarshalMUS(buf[i:])
+		if err == nil {
+			v.ObjectTypeID = sv
+			i += si
+		}
+	}
+	if err != nil {
+		return i, muserrs.NewFieldError("ObjectTypeID", err)
 	}
 	{
 		var sv umid.UMID
@@ -256,6 +272,10 @@ func (v ObjectDefinition) SizeMUS() int {
 	}
 	{
 		ss := v.ParentID.SizeMUS()
+		size += ss
+	}
+	{
+		ss := v.ObjectTypeID.SizeMUS()
 		size += ss
 	}
 	{

--- a/pkg/posbus/object_definition.go
+++ b/pkg/posbus/object_definition.go
@@ -9,6 +9,7 @@ import (
 type ObjectDefinition struct {
 	ID               umid.UMID       `json:"id"`
 	ParentID         umid.UMID       `json:"parent_id"`
+	ObjectTypeID     umid.UMID       `json:"object_type_id"`
 	AssetType        umid.UMID       `json:"asset_type"`
 	AssetFormat      dto.Asset3dType `json:"asset_format"` // TODO: Rename AssetType to AssetID, so Type can be used for this.
 	Name             string          `json:"name"`

--- a/universe/object/object.go
+++ b/universe/object/object.go
@@ -635,7 +635,7 @@ func (o *Object) UpdateSpawnMessage() error {
 	}
 
 	mData := make([]posbus.ObjectDefinition, 1)
-	mData[0] = posbus.ObjectDefinition{ID: o.GetID(), ParentID: parentID, AssetType: asset3dID, AssetFormat: assetFormat, Name: o.GetName(), IsEditable: *utils.GetFromAny(
+	mData[0] = posbus.ObjectDefinition{ID: o.GetID(), ParentID: parentID, ObjectTypeID: objectType.GetID(), AssetType: asset3dID, AssetFormat: assetFormat, Name: o.GetName(), IsEditable: *utils.GetFromAny(
 		effectiveOptions.Editable, utils.GetPTR(true),
 	),
 		ShowOnMiniMap: *utils.GetFromAny(effectiveOptions.Minimap, &visible), Transform: *o.GetActualTransform()}


### PR DESCRIPTION
It's useful to have in add_objects message - currently we need it to recognise User Customisable objects to fetch additional attribute data and apply a special view.