### PR TITLE
feat: fields in response of failed lock/unlock request

### DIFF
--- a/pkg/posbus/LockObjectResponse.mus.go
+++ b/pkg/posbus/LockObjectResponse.mus.go
@@ -15,12 +15,12 @@ func (v LockObjectResponse) MarshalMUS(buf []byte) int {
 		i += si
 	}
 	{
-		for v.State >= 0x80 {
-			buf[i] = byte(v.State) | 0x80
-			v.State >>= 7
+		for v.Result >= 0x80 {
+			buf[i] = byte(v.Result) | 0x80
+			v.Result >>= 7
 			i++
 		}
-		buf[i] = byte(v.State)
+		buf[i] = byte(v.Result)
 		i++
 	}
 	{
@@ -57,12 +57,12 @@ func (v *LockObjectResponse) UnmarshalMUS(buf []byte) (int, error) {
 				return i, muserrs.ErrOverflow
 			}
 			if b < 0x80 {
-				v.State = v.State | uint32(b)<<shift
+				v.Result = v.Result | uint32(b)<<shift
 				done = true
 				i += l + 1
 				break
 			}
-			v.State = v.State | uint32(b&0x7F)<<shift
+			v.Result = v.Result | uint32(b&0x7F)<<shift
 			shift += 7
 		}
 		if !done {
@@ -70,7 +70,7 @@ func (v *LockObjectResponse) UnmarshalMUS(buf []byte) (int, error) {
 		}
 	}
 	if err != nil {
-		return i, muserrs.NewFieldError("State", err)
+		return i, muserrs.NewFieldError("Result", err)
 	}
 	{
 		var sv umid.UMID
@@ -95,8 +95,8 @@ func (v LockObjectResponse) SizeMUS() int {
 		size += ss
 	}
 	{
-		for v.State >= 0x80 {
-			v.State >>= 7
+		for v.Result >= 0x80 {
+			v.Result >>= 7
 			size++
 		}
 		size++

--- a/pkg/posbus/object_lock.go
+++ b/pkg/posbus/object_lock.go
@@ -12,7 +12,7 @@ type UnlockObject struct {
 
 type LockObjectResponse struct {
 	ID        umid.UMID `json:"id"`
-	State     uint32    `json:"result"`
+	Result    uint32    `json:"result"`
 	LockOwner umid.UMID `json:"lock_owner"`
 }
 

--- a/universe/interfaces.go
+++ b/universe/interfaces.go
@@ -230,6 +230,7 @@ type Object interface {
 	SendAllAutoAttributes(sendFn func(msg *websocket.PreparedMessage) error, recursive bool)
 
 	LockUIObject(user User, state uint32) bool
+	GetLockUserID() umid.UMID
 	IsLockedByUser(user User) bool
 
 	GetCreatedAt() time.Time

--- a/universe/object/object.go
+++ b/universe/object/object.go
@@ -725,14 +725,18 @@ func (o *Object) LockUIObject(user universe.User, state uint32) bool {
 	}
 }
 
+func (o *Object) IsLockedByUser(user universe.User) bool {
+	return o.lockedBy.Load() == user.GetID()
+}
+
+func (o *Object) GetLockUserID() umid.UMID {
+	return o.lockedBy.Load().(umid.UMID)
+}
+
 func (o *Object) GetCreatedAt() time.Time {
 	return o.createdAt
 }
 
 func (o *Object) GetUpdatedAt() time.Time {
 	return o.updatedAt
-}
-
-func (o *Object) IsLockedByUser(user universe.User) bool {
-	return o.lockedBy.Load() == user.GetID()
 }

--- a/universe/user/message_loop.go
+++ b/universe/user/message_loop.go
@@ -189,11 +189,12 @@ func (u *User) LockObject(lock *posbus.LockObject) error {
 	result := object.LockUIObject(u, 1)
 	if result {
 		return u.GetWorld().Send(
-			posbus.WSMessage(&posbus.LockObjectResponse{ID: objectId, State: 1, LockOwner: u.GetID()}),
+			posbus.WSMessage(&posbus.LockObjectResponse{ID: objectId, Result: 1, LockOwner: u.GetID()}),
 			true,
 		)
 	}
-	return u.Send(posbus.WSMessage(&posbus.LockObjectResponse{ID: objectId, State: 0, LockOwner: u.GetID()}))
+	lockOwner := object.GetLockUserID()
+	return u.Send(posbus.WSMessage(&posbus.LockObjectResponse{ID: objectId, Result: 0, LockOwner: lockOwner}))
 }
 
 func (u *User) UnlockObject(lock *posbus.UnlockObject) error {
@@ -207,11 +208,12 @@ func (u *User) UnlockObject(lock *posbus.UnlockObject) error {
 
 	if result {
 		return u.GetWorld().Send(
-			posbus.WSMessage(&posbus.LockObjectResponse{ID: objectId, State: 1, LockOwner: u.GetID()}),
+			posbus.WSMessage(&posbus.LockObjectResponse{ID: objectId, Result: 1, LockOwner: u.GetID()}),
 			true,
 		)
 	}
-	return u.Send(posbus.WSMessage(&posbus.LockObjectResponse{ID: objectId, State: 1, LockOwner: u.GetID()}))
+	lockOwner := object.GetLockUserID()
+	return u.Send(posbus.WSMessage(&posbus.LockObjectResponse{ID: objectId, Result: 0, LockOwner: lockOwner}))
 }
 
 func (u *User) HandleHighFive(m *posbus.HighFive) error {

--- a/universe/user/message_loop.go
+++ b/universe/user/message_loop.go
@@ -208,7 +208,7 @@ func (u *User) UnlockObject(lock *posbus.UnlockObject) error {
 
 	if result {
 		return u.GetWorld().Send(
-			posbus.WSMessage(&posbus.LockObjectResponse{ID: objectId, Result: 1, LockOwner: u.GetID()}),
+			posbus.WSMessage(&posbus.LockObjectResponse{ID: objectId, Result: 1, LockOwner: umid.Nil}),
 			true,
 		)
 	}

--- a/universe/world/users.go
+++ b/universe/world/users.go
@@ -152,7 +152,7 @@ func (w *World) noLockRemoveUser(user universe.User, updateDB bool) (bool, error
 	for _, child := range w.allObjects.Data {
 		if child.LockUIObject(user, 0) {
 			w.Send(
-				posbus.WSMessage(&posbus.LockObjectResponse{ID: child.GetID(), Result: 0, LockOwner: user.GetID()}),
+				posbus.WSMessage(&posbus.LockObjectResponse{ID: child.GetID(), Result: 0, LockOwner: umid.Nil}),
 				true,
 			)
 		}

--- a/universe/world/users.go
+++ b/universe/world/users.go
@@ -152,7 +152,7 @@ func (w *World) noLockRemoveUser(user universe.User, updateDB bool) (bool, error
 	for _, child := range w.allObjects.Data {
 		if child.LockUIObject(user, 0) {
 			w.Send(
-				posbus.WSMessage(&posbus.LockObjectResponse{ID: child.GetID(), State: 0, LockOwner: user.GetID()}),
+				posbus.WSMessage(&posbus.LockObjectResponse{ID: child.GetID(), Result: 0, LockOwner: user.GetID()}),
 				true,
 			)
 		}


### PR DESCRIPTION
Renaming the field, on the golang side, to match the JSON.
And then fix its actual value, when it is send.

So the way it works, for future reference:
Client send lock request -> World broadcast of `{id: "42", result:1, lock_owner: "AAA"}`
Somebody else sends lock request -> Response only to this user `{id: "42", result:0, lock_owner: "AAA"}`
Somebody else sends unlock request -> Response only to this user `{id: "42", result:0, lock_owner: "AAA"}`
Client send unlock -> World broadcast of `{id: "42", result:1, lock_owner: "UUID(nil)"}`

--> so 'result': 0 goes to 1 user. 'result: 1' is world broadcast.
If client wants to know (currently we don't visually show it, but for the future): have to use the lock_owner field to figure out if a lock or unlock was send, by comparing against uuid nil value.
Or can use the non-nil UUID to show a message who's holding the lock.




