### PR TITLE
feat: api endpoint for combined object user attribute list entries

### DIFF
--- a/database/interfaces.go
+++ b/database/interfaces.go
@@ -375,6 +375,20 @@ type ObjectUserAttributesDB interface {
 	RemoveObjectUserAttributesByPluginIDAndObjectIDAndUserID(
 		ctx context.Context, pluginID umid.UMID, objectID umid.UMID, userID umid.UMID,
 	) error
+
+	ValueEntries(
+		ctx context.Context,
+		attrID entry.ObjectAttributeID,
+		fields []string,
+		order string,
+		descending bool,
+		limit uint,
+		offset uint,
+	) ([]map[string]interface{}, error)
+	ValueEntriesCount(
+		ctx context.Context,
+		objectAttributeID entry.ObjectAttributeID,
+	) (uint, error)
 }
 
 type UserAttributesDB interface {

--- a/database/object_user_attributes/db.go
+++ b/database/object_user_attributes/db.go
@@ -2,6 +2,8 @@ package object_user_attributes
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -572,4 +574,104 @@ func (db *DB) UpdateObjectUserAttributeOptions(
 	}
 
 	return options, nil
+}
+
+// ValueEntries returns a combined, sorted, list of nested items inside a attribute.
+// fields is the list of field name returned for each nested items, should be simple values (are seen as strings).
+//
+// The JSON value is expectd to be an object with key->item format.
+// The key being some unique identifier and the item some nested JSON.
+//
+//	{
+//	  "id-1": {"title": "bar", "some": {"thing": 1}},
+//	  "id-2": {"title": "qux", "some": {"other": "thing"}}
+//	}
+//
+// The result:
+//
+// [{"_key": "id-1", "_user": "{...}", "title": "bar"},{"_key": "id-2", "_user": "{...}", title": "qux"}]
+func (db *DB) ValueEntries(
+	ctx context.Context,
+	attrID entry.ObjectAttributeID,
+	fields []string,
+	order string,
+	descending bool,
+	limit uint,
+	offset uint,
+) ([]map[string]interface{}, error) {
+	// TODO: pick a sql query builder library? if we are gonna do this more often,
+	// string concat starts to suck.
+	sql := `SELECT entry.key as "_key",
+	        jsonb_build_object(
+			  'user_id', u.user_id,
+	          'profile', u.profile
+            ) as "_user"`
+	if len(fields) > 0 {
+		sql += ", item.*"
+	}
+	sql += `
+	FROM object_user_attribute as attr
+		 INNER JOIN "user" AS u USING (user_id),
+         jsonb_each(attr.value) as entry`
+	if len(fields) > 0 {
+		sqlRecordTypes := []string{}
+		for _, field := range fields {
+			ident := pgx.Identifier([]string{field}).Sanitize()
+			sqlRecordTypes = append(sqlRecordTypes, ident+" text") // TODO: configurables 'types' instead of text
+		}
+		itemType := fmt.Sprintf("item(%s)", strings.Join(sqlRecordTypes, ","))
+		sql += `,
+		jsonb_to_record(entry.value) AS ` + itemType
+	}
+	sql += `
+    WHERE
+      attr.plugin_id = $1 
+	  AND attr.attribute_name = $2
+	  AND attr.object_id = $3
+	`
+	if order != "" {
+		// TODO: handle the case when no fields gives (value->'foo' should be used)
+		// But that requires dynamic query params and we don't have named params support.
+		orderBy := pgx.Identifier([]string{"item", order}).Sanitize()
+		sql += "ORDER BY " + orderBy
+		if descending {
+			sql += "DESC\n"
+		} else {
+			sql += "\n"
+		}
+	}
+	if limit > 0 {
+		sql += fmt.Sprintf("LIMIT %d ", limit)
+	}
+	if offset > 0 {
+		sql += fmt.Sprintf("OFFSET %d", offset)
+	}
+	sql += ";"
+	var itemList []map[string]interface{}
+	qArgs := []interface{}{attrID.PluginID, attrID.Name, attrID.ObjectID}
+	if err := pgxscan.Select(ctx, db.conn, &itemList, sql, qArgs...); err != nil {
+		return nil, err
+	}
+	return itemList, nil
+
+}
+
+// ValueEntriesCount return the number of nested entries in the JSON value.
+// This assumes an JSON object in the value field.
+// Each entry (key) in this object is counted.
+func (db *DB) ValueEntriesCount(
+	ctx context.Context,
+	objectAttributeID entry.ObjectAttributeID,
+) (uint, error) {
+	var count uint
+	sql := `SELECT count(*) FROM (
+		SELECT jsonb_object_keys(value) FROM object_user_attribute
+			WHERE plugin_id = $1 AND attribute_name = $2 AND object_id = $3
+	) oua;`
+	if err := db.conn.QueryRow(ctx, sql,
+		objectAttributeID.PluginID, objectAttributeID.Name, objectAttributeID.ObjectID,
+	).Scan(&count); err != nil {
+		return 0, errors.WithMessage(err, "failed to query db")
+	}
+	return count, nil
 }

--- a/universe/attributes/api_common.go
+++ b/universe/attributes/api_common.go
@@ -36,3 +36,26 @@ func PluginAttributeFromQuery(c *gin.Context, n universe.Node) (universe.Attribu
 	attrID = entry.NewAttributeID(pluginID, inQuery.AttributeName)
 	return attrType, attrID, nil
 }
+
+// Get plugin attribute definition from API URL params.
+func PluginAttributeFromURL(c *gin.Context, n universe.Node) (universe.AttributeType, entry.AttributeID, error) {
+	var attrID entry.AttributeID
+	pluginID, err := umid.Parse(c.Param("pluginID"))
+	if err != nil {
+		err := fmt.Errorf("invalid plugin ID: %w", err)
+		return nil, attrID, err
+	}
+	attrName := c.Param("attrName")
+	if attrName == "" {
+		err := fmt.Errorf("invalid attribute name: \"%s\"", attrName)
+		return nil, attrID, err
+	}
+	attrType, ok := n.GetAttributeTypes().GetAttributeType(
+		entry.AttributeTypeID{PluginID: pluginID, Name: attrName})
+	if !ok {
+		err := fmt.Errorf("attribute type not found with %s %s", pluginID, attrName)
+		return nil, attrID, err
+	}
+	attrID = entry.NewAttributeID(pluginID, attrName)
+	return attrType, attrID, nil
+}

--- a/universe/node/api.go
+++ b/universe/node/api.go
@@ -175,6 +175,7 @@ func (n *Node) RegisterAPI(r *gin.Engine) {
 
 				object.GET("/all-users/attributes", n.apiGetObjectAllUsersAttributeValuesList)
 				object.GET("/all-users/count", n.apiGetObjectUserAttributeCount)
+				object.GET("/all-users/attributes/:pluginID/:attrName/entries", n.apiObjectUserAttributeValueEntries)
 
 				timeline := object.Group("/timeline")
 				{
@@ -206,6 +207,7 @@ func (n *Node) RegisterAPI(r *gin.Engine) {
 				objectUser.DELETE("/attributes/sub", n.apiRemoveObjectUserAttributeSubValue)
 
 				objectUser.GET("/attributes", n.apiGetObjectUserAttributesValue)
+
 				objectUser.GET("/attributes/sub", n.apiGetObjectUserAttributeSubValue)
 			}
 		}

--- a/universe/node/api_object_user_attributes.go
+++ b/universe/node/api_object_user_attributes.go
@@ -3,10 +3,12 @@ package node
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
+	"golang.org/x/exp/slices"
 
 	"github.com/momentum-xyz/ubercontroller/types/entry"
 	"github.com/momentum-xyz/ubercontroller/universe/attributes"
@@ -729,4 +731,118 @@ func (n *Node) apiGetObjectUserAttributeCount(c *gin.Context) {
 	out := dto.AttributeCount{Count: count}
 
 	c.JSON(http.StatusOK, out)
+}
+
+// @Summary Get combined list of json entries from all user's values.
+// @Description Allow showing a combined (sorted) list from all users.
+// @Description The attribute value is assumed to be a JSON (map-like) object, with some ID as key and the value nested JSON object.
+// @Description The fields params allows selecting some fields to directly return in the list.
+// @Description The limit and offset params allow pagination.
+// @Description Limit defaults to 10, maximun allowed is 100.
+// @Tags objects
+// @Accept json
+// @Produce json
+// @Param object_id path string true "Object UMID"
+// @Param plugin_id path string true "Plugin MID"
+// @Param attribute_name path string true "Name of the plugin attribute"
+// @Param query query node.apiObjectUserAttributeValueEntries.InQuery false "query params"
+// @Success 202 {object} node.apiObjectUserAttributeValueEntries.JsonResult
+// @Failure 400 {object} api.HTTPError
+// @Failure 404 {object} api.HTTPError
+// @Router /api/v4/objects/{object_id}/all-users/attributes/{plugin_id}/{attribute_name}/entries [get]
+func (n *Node) apiObjectUserAttributeValueEntries(c *gin.Context) {
+	objectID, err := umid.Parse(c.Param("objectID"))
+	if err != nil {
+		err := fmt.Errorf("invalid object ID: %w", err)
+		api.AbortRequest(c, http.StatusBadRequest, "invalid_param", err, n.log)
+		return
+	}
+	attrType, attrID, err := attributes.PluginAttributeFromURL(c, n)
+	if err != nil {
+		err := fmt.Errorf("plugin attribute: %w", err)
+		api.AbortRequest(c, http.StatusNotFound, "invalid_param", err, n.log)
+		return
+	}
+	userID, err := api.GetUserIDFromContext(c)
+	if err != nil {
+		err := fmt.Errorf("user from context: %w", err)
+		api.AbortRequest(c, http.StatusBadRequest, "invalid_user", err, n.log)
+		return
+	}
+	allowed, err := auth.CheckReadAllPermissions[entry.ObjectUserAttributeID](
+		c, *attrType.GetEntry(), n.GetObjectUserAttributes(), userID)
+	if err != nil {
+		err := fmt.Errorf("check read permissions: %w", err)
+		api.AbortRequest(c, http.StatusInternalServerError, "failed_permissions_check", err, n.log)
+		return
+	}
+	if !allowed {
+		err := fmt.Errorf("operation not permitted")
+		api.AbortRequest(c, http.StatusForbidden, "operation_not_permitted", err, n.log)
+		return
+	}
+
+	type InQuery struct {
+		Fields  []string `form:"field"`
+		OrderBy string   `form:"order"`
+		Limit   uint     `form:"limit,default=10"`
+		Offset  uint     `form:"offset"`
+	}
+	var q InQuery
+	if err := c.ShouldBindQuery(&q); err != nil {
+		err := fmt.Errorf("bind query: %w", err)
+		api.AbortRequest(c, http.StatusBadRequest, "invalid_query", err, n.log)
+	}
+	var limit uint
+	if q.Limit > 100 { // TODO: go 1.21 max function
+		limit = 100
+	} else {
+		limit = q.Limit
+	}
+	objAttrID := entry.NewObjectAttributeID(attrID, objectID)
+	oua := n.db.GetObjectUserAttributesDB()
+	count, err := oua.ValueEntriesCount(c, objAttrID)
+	if err != nil {
+		err := fmt.Errorf("count query: %w", err)
+		api.AbortRequest(c, http.StatusInternalServerError, "invalid_params", err, n.log)
+		return
+	}
+	type JsonResult struct {
+		Count  uint                     `json:"count"`
+		Limit  uint                     `json:"limit"`
+		Offset uint                     `json:"offset"`
+		Items  []map[string]interface{} `json:"items"`
+	}
+	if count == 0 {
+		c.JSON(http.StatusOK, JsonResult{Limit: limit})
+		return
+	}
+	order := q.OrderBy
+	desc := false
+	if q.OrderBy != "" {
+		if strings.HasPrefix(order, "-") {
+			desc = true
+			order = strings.TrimPrefix(order, "-")
+		}
+		if !slices.Contains(q.Fields, order) { // TODO: handle this, instead of error
+			err := errors.New("order field should be included in fields")
+			api.AbortRequest(c, http.StatusBadRequest, "invalid_params", err, n.log)
+			return
+		}
+	}
+	itemList, err := oua.ValueEntries(
+		c, objAttrID, q.Fields, order, desc, limit, q.Offset)
+	if err != nil {
+		err := fmt.Errorf("query: %w", err)
+		api.AbortRequest(c, http.StatusInternalServerError, "invalid query", err, n.log)
+		return
+	}
+
+	result := JsonResult{
+		Count:  count,
+		Limit:  limit,
+		Offset: q.Offset,
+		Items:  itemList,
+	}
+	c.JSON(http.StatusOK, result)
 }


### PR DESCRIPTION
For the usecase of storing multiple JSON 'items' inside an object-user attribute and then wanting to show a combined/merged list over all users.

Based on some previously implemented usages of object-user attributes. Where some JSON objects are 'set' with the `.../attributes/sub` endpoint (so basically setting a key-value entries). This endpoint then allows a lookup of all the entries from users, in a sorted&paginated way.

Current limitations (which could be improved if needed): 
selected `field` (query param) values are treated as text only, so sorting is also only text-based (e.g. we are assuming iso-8601 timestamp strings). And these can't be nested JSON (again, assuming this is for a listing, where details can be retrieved on-demand with other API call).

`field` params was mainly added to avoid having to 'implement' full jsonpath support
