### PR TITLE
feat: cli migrate only option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ migrate create -ext sql -dir database/migrations/sql/ -seq <SHORT_NAME_FOR_MIGRA
 Two empty .sql files will be created in `database/migrations/sql`.
 Implemented them and to test it:
 ```
-migrate -source file://database/migrations/sql/ -database postgres://momentum:momentum@localhost:4321/momentum?sslmode=disable up
+go run ./cmd/service/ -migrate
 ```
 
 And to revert the change:
 ```
-migrate -source file://database/migrations/sql/ -database postgres://momentum:momentum@localhost:4321/momentum?sslmode=disable down 1
+go run ./cmd/service/ -migrate -steps -1
 ```
 
 If something goes wrong, it will leave the database in a 'dirty' state.

--- a/pkg/service/run.go
+++ b/pkg/service/run.go
@@ -174,7 +174,7 @@ func CreateDBConnection(ctx types.NodeContext, cfg *config.Postgres) (*pgxpool.P
 		return nil, errors.WithMessage(err, "failed to gen postgres config")
 	}
 
-	if err := migrations.MigrateDatabase(ctx, cfg); err != nil {
+	if err := migrations.MigrateDatabase(ctx, cfg, 0); err != nil {
 		return nil, errors.WithMessage(err, "failed to migrate database")
 	}
 


### PR DESCRIPTION
For testing up/downs of migrations, since the plain golang-migrate cli doesn't work with the custom templating/variables.