### PR TITLE
feat(api): optional filters on object_user attr list

### DIFF
--- a/database/interfaces.go
+++ b/database/interfaces.go
@@ -380,6 +380,7 @@ type ObjectUserAttributesDB interface {
 		ctx context.Context,
 		attrID entry.ObjectAttributeID,
 		fields []string,
+		filters map[string]string,
 		order string,
 		descending bool,
 		limit uint,
@@ -388,6 +389,7 @@ type ObjectUserAttributesDB interface {
 	ValueEntriesCount(
 		ctx context.Context,
 		objectAttributeID entry.ObjectAttributeID,
+		filters map[string]string,
 	) (uint, error)
 }
 

--- a/universe/node/api_object_user_attributes.go
+++ b/universe/node/api_object_user_attributes.go
@@ -721,6 +721,7 @@ func (n *Node) apiGetObjectUserAttributeCount(c *gin.Context) {
 // @Description Allow showing a combined (sorted) list from all users.
 // @Description The attribute value is assumed to be a JSON (map-like) object, with some ID as key and the value nested JSON object.
 // @Description The fields params allows selecting some fields to directly return in the list.
+// @Description A field name given in the fields param can also be used as a query param to filter on value.
 // @Description The limit and offset params allow pagination.
 // @Description Limit defaults to 10, maximun allowed is 100.
 // @Tags attributes,objects
@@ -782,9 +783,16 @@ func (n *Node) apiObjectUserAttributeValueEntries(c *gin.Context) {
 	} else {
 		limit = q.Limit
 	}
+	filters := map[string]string{}
+	for _, f := range q.Fields {
+		val, ok := c.GetQuery(f)
+		if ok {
+			filters[f] = val
+		}
+	}
 	objAttrID := entry.NewObjectAttributeID(attrID, objectID)
 	oua := n.db.GetObjectUserAttributesDB()
-	count, err := oua.ValueEntriesCount(c, objAttrID)
+	count, err := oua.ValueEntriesCount(c, objAttrID, filters)
 	if err != nil {
 		err := fmt.Errorf("count query: %w", err)
 		api.AbortRequest(c, http.StatusInternalServerError, "invalid_params", err, n.log)
@@ -814,7 +822,7 @@ func (n *Node) apiObjectUserAttributeValueEntries(c *gin.Context) {
 		}
 	}
 	itemList, err := oua.ValueEntries(
-		c, objAttrID, q.Fields, order, desc, limit, q.Offset)
+		c, objAttrID, q.Fields, filters, order, desc, limit, q.Offset)
 	if err != nil {
 		err := fmt.Errorf("query: %w", err)
 		api.AbortRequest(c, http.StatusInternalServerError, "invalid query", err, n.log)


### PR DESCRIPTION
Optionally allow query params to filter the result. The name of the query params has to be in the fields[] list.

Limitation is that it currently only supports a string/text equality comparison of the json value.