### PR TITLE
New attribute for texture, multiple object functions - image/text/video

### DIFF
--- a/database/migrations/sql/000699_object_content_attributes.down.sql
+++ b/database/migrations/sql/000699_object_content_attributes.down.sql
@@ -1,0 +1,51 @@
+BEGIN;
+
+UPDATE attribute_type
+	SET "options"='{"cloneable": {}, "render_auto": {"slot_name": "object_texture", "slot_type": "texture", "content_type": "image"}}'
+	WHERE plugin_id='ff40fbf0-8c22-437d-b27a-0258f99130fe'::uuid AND attribute_name='state';
+
+UPDATE object_attribute oa
+SET    plugin_id = 'ff40fbf0-8c22-437d-b27a-0258f99130fe',
+       attribute_name = 'state'
+WHERE  attribute_name = 'texture'
+AND NOT EXISTS (
+	SELECT 1
+	FROM object_attribute
+	WHERE object_id = oa.object_id AND plugin_id = 'ff40fbf0-8c22-437d-b27a-0258f99130fe' AND attribute_name = 'state'
+);
+
+UPDATE object
+	SET asset_2d_id = '7be0964f-df73-4880-91f5-22eef9967999'
+	WHERE object_id IN
+	(
+		SELECT object_id
+		FROM object_attribute
+		WHERE plugin_id = 'ff40fbf0-8c22-437d-b27a-0258f99130fe' AND attribute_name = 'state'
+	);
+
+UPDATE object
+	SET asset_2d_id = 'be0d0ca3-c50b-401a-89d9-0e59fc45c5c2'
+	WHERE object_id IN
+	(
+		SELECT object_id
+		FROM object_attribute
+		WHERE plugin_id = 'fc9f2eb7-590a-4a1a-ac75-cd3bfeef28b2' AND attribute_name = 'state'
+	);
+
+UPDATE object
+	SET asset_2d_id = 'bda25d5d-2aab-45b4-9e8a-23579514cec1'
+	WHERE object_id IN
+	(
+		SELECT object_id
+		FROM object_attribute
+		WHERE plugin_id = '308fdacc-8c2d-40dc-bd5f-d1549e3e03ba' AND attribute_name = 'state'
+	);
+	
+
+DELETE FROM attribute_type 
+WHERE plugin_id = 'f0f0f0f0-0f0f-4ff0-af0f-f0f0f0f0f0f0' AND attribute_name = 'texture';
+
+DELETE FROM asset_2d
+WHERE asset_2d_id = '7be0964f-df73-4880-91f5-22eef996beef';
+
+COMMIT;

--- a/database/migrations/sql/000699_object_content_attributes.up.sql
+++ b/database/migrations/sql/000699_object_content_attributes.up.sql
@@ -1,0 +1,52 @@
+BEGIN;
+
+INSERT INTO asset_2d (asset_2d_id, meta)
+	VALUES ('7be0964f-df73-4880-91f5-22eef996beef','{
+  "name": "object_content",
+  "pluginId": "f0f0f0f0-0f0f-4ff0-af0f-f0f0f0f0f0f0"
+}')
+ON CONFLICT (asset_2d_id) DO NOTHING;
+
+
+INSERT INTO attribute_type (plugin_id, attribute_name, description, "options")
+	VALUES ('f0f0f0f0-0f0f-4ff0-af0f-f0f0f0f0f0f0','texture','Object texture','{"cloneable": {}, "render_auto": {"slot_name": "object_texture", "slot_type": "texture", "content_type": "image"}}')
+ON CONFLICT (plugin_id,attribute_name) DO NOTHING;
+
+UPDATE attribute_type
+	SET "options"='{"render_auto": {"slot_name": "object_image", "slot_type": "texture", "content_type": "image"}}'
+	WHERE plugin_id='ff40fbf0-8c22-437d-b27a-0258f99130fe'::uuid AND attribute_name='state';
+
+
+UPDATE object_attribute oa
+SET    plugin_id = 'f0f0f0f0-0f0f-4ff0-af0f-f0f0f0f0f0f0',
+       attribute_name = 'texture'
+WHERE  attribute_name = 'state'
+       AND plugin_id = 'ff40fbf0-8c22-437d-b27a-0258f99130fe'
+       AND oa.object_id IN (SELECT o.object_id
+                            FROM   "object" o
+                            WHERE  o.asset_3d_id IN (SELECT ad.asset_3d_id
+                                                     FROM   asset_3d ad
+                                                     WHERE
+                                   ad.meta ->> 'category' =
+                                   'basic'));
+
+UPDATE object
+  SET asset_2d_id = '7be0964f-df73-4880-91f5-22eef996beef'
+  WHERE asset_2d_id IN (
+    'be0d0ca3-c50b-401a-89d9-0e59fc45c5c2',
+    'bda25d5d-2aab-45b4-9e8a-23579514cec1'
+    );
+
+UPDATE object
+  SET asset_2d_id = NULL
+  WHERE asset_2d_id = '7be0964f-df73-4880-91f5-22eef9967999';
+
+UPDATE object
+  SET asset_2d_id = '7be0964f-df73-4880-91f5-22eef996beef'
+  WHERE object_id IN (
+    SELECT object_id
+    FROM object_attribute
+    WHERE plugin_id = 'ff40fbf0-8c22-437d-b27a-0258f99130fe' AND attribute_name = 'state'
+  );
+
+COMMIT;


### PR DESCRIPTION
We want to be able to set multiple "functions" as text/image/video to single object as well as separate texture image.
For this we introduce new asset_2d and create new attribute type texture, while modifying the old one for image state so it wouldn't trigger the texture setting in UI client.

The attributes are also migrated. Image attributes associated with basic models are migrated to the new "texture" attribute while the ones associated with custom models are left as is.

asset_2d_id for objects with image/text/video is also migrated to new asset_2d named object_content. For the case of image, only the ones remaining with plugin_id image (not wrapped textures) are assigned the new asset_2d_id. The objects with textures only have their asset_2d_id nulled.