### PR TITLE
Fix/seed media files

### DIFF
--- a/pkg/media/processor/images.go
+++ b/pkg/media/processor/images.go
@@ -3,7 +3,6 @@ package processor
 import (
 	"bytes"
 	"errors"
-	"github.com/momentum-xyz/ubercontroller/types"
 	"image"
 	_ "image/gif"
 	_ "image/jpeg"
@@ -11,6 +10,8 @@ import (
 	_ "image/png"
 	"math"
 	"os"
+
+	"github.com/momentum-xyz/ubercontroller/types"
 
 	"github.com/nfnt/resize"
 	_ "golang.org/x/image/webp"
@@ -29,7 +30,12 @@ func (p *Processor) WriteToF(img image.Image) (error, string) {
 
 func (p *Processor) WriteToScaled(base string, img image.Image, rsize string) error {
 	if size, ok := types.Tsizes[rsize]; ok {
-		return p.SaveWriteToPNG(p.ImPathS[rsize]+base, DownSampleTo(img, size))
+		fpath := p.ImPathS[rsize] + base
+		if p.FileExists(fpath) {
+			p.log.Debugf("Scaled file %s already exist, skip", fpath)
+			return nil
+		}
+		return p.SaveWriteToPNG(fpath, DownSampleTo(img, size))
 	}
 	return errors.New("Not such size defined in the size map")
 


### PR DESCRIPTION
'quickfix' for triggering the seeding of default media files.

It was never triggered because the 'node' is now already created in the
db/sql migrations. Now just always trigger it, so this impacts startup time. 
Slightly compensate by also avoiding rescaling here if the scaled file already exists.
So for now, let's see how it runs...

I suspect this whole 'pre-scaling' it does here isn't need anymore and it could just call into the other code flow of 'background' processing these (which already does caching and avoiding duplicate work), but leaving that for later.

